### PR TITLE
Correct the docs and examples regarding the message ID property

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Sends a message. A message is an object that may contain the following fields:
   * content_type
   * content_encoding
   * group_id
-  * id
+  * message_id
   * correlation_id
   * application_properties, an object/map which can take arbitrary, application defined named values
   * body, which can be either a string, an object or a buffer

--- a/examples/direct_send.js
+++ b/examples/direct_send.js
@@ -29,7 +29,7 @@ container.on('sendable', function (context) {
     while (context.sender.sendable() && sent < total) {
         sent++;
         console.log('sent ' + sent);
-        context.sender.send({id:sent, body:{'sequence':sent}});
+        context.sender.send({message_id:sent, body:{'sequence':sent}});
     }
     if (sent === total) {
         context.sender.set_drained(sent === total);


### PR DESCRIPTION
This test fails for me.

`diff --git a/test/messages.ts b/test/messages.ts
index 3e3b1e0..0195674 100644
--- a/test/messages.ts
+++ b/test/messages.ts
@@ -105,6 +105,9 @@ describe('message content', function() {
     it('sends and receives message-id as long', transfer_test({message_id:12345}, function(message: rhea.Message) {
         assert.equal(message.message_id, 12345);
     }));
+    it('sends and receives message-id set using \'id\'', transfer_test({id:'my-id'}, function(message: rhea.Message) {
+        assert.equal(message.message_id, 'my-id');
+    }));
     var test_uuid = rhea_util.uuid4();
     it('sends and receives message-id as uuid', transfer_test({message_id:test_uuid}, function(message: rhea.Message) {
         assert.equal(rhea.uuid_to_string(message.message_id as Buffer), rhea.uuid_to_string(test_uuid));`

(I would personally prefer supporting message.id, but I didn't find any existing facility to handle aliases when processing user message data.)