### PR TITLE
Added sender_flow, receiver_flow, protocol_error, error events

### DIFF
--- a/lib/eventTypes.js
+++ b/lib/eventTypes.js
@@ -33,6 +33,10 @@ var ReceiverEvents;
      */
     ReceiverEvents['receiverDrained'] = 'receiver_drained';
     /**
+     * @property {string} receiverFlow Raised when a flow is received for receiver.
+     */
+    ReceiverEvents['receiverFlow'] = 'receiver_flow';
+    /**
      * @property {string} receiverError Raised when the remote peer
      * closes the receiver with an error. The context may also have an
      * error property giving some information about the reason for the
@@ -68,6 +72,10 @@ var SenderEvents;
      * is used up..
      */
     SenderEvents['senderDraining'] = 'sender_draining';
+    /**
+     * @property {string} senderFlow Raised when a flow is received for sender.
+     */
+    SenderEvents['senderFlow'] = 'sender_flow';
     /**
      * @property {string} senderError Raised when the remote peer
      * closes the sender with an error. The context may also have an
@@ -139,6 +147,14 @@ var ConnectionEvents;
      * the connection.
      */
     ConnectionEvents['connectionError'] = 'connection_error';
+    /**
+     * @property {string} protocolError Raised when a protocol error is received on the underlying socket.
+     */
+    ConnectionEvents['protocolError'] = 'protocol_error',
+    /**
+     * @property {string} error Raised when an error is received on the underlying socket.
+     */
+    ConnectionEvents['error'] = 'error',
     /**
      * @property {string} disconnected Raised when the underlying tcp connection is lost. The context
      * has a reconnecting property which is true if the library is attempting to automatically reconnect

--- a/test/eventTypes.ts
+++ b/test/eventTypes.ts
@@ -22,6 +22,7 @@ describe('event types', function() {
         assert.equal(rhea.ReceiverEvents.message, "message");
         assert.equal(rhea.ReceiverEvents.receiverClose, "receiver_close");
         assert.equal(rhea.ReceiverEvents.receiverDrained, "receiver_drained");
+        assert.equal(rhea.ReceiverEvents.receiverFlow, "receiver_flow");
         assert.equal(rhea.ReceiverEvents.receiverError, "receiver_error");
         assert.equal(rhea.ReceiverEvents.receiverOpen, "receiver_open");
         assert.equal(rhea.ReceiverEvents.settled, "settled");
@@ -33,6 +34,7 @@ describe('event types', function() {
         assert.equal(rhea.SenderEvents.released, "released");
         assert.equal(rhea.SenderEvents.modified, "modified");
         assert.equal(rhea.SenderEvents.senderDraining, "sender_draining");
+        assert.equal(rhea.SenderEvents.senderFlow, "sender_flow");
         assert.equal(rhea.SenderEvents.sendable, "sendable");
         assert.equal(rhea.SenderEvents.senderClose, "sender_close");
         assert.equal(rhea.SenderEvents.senderError, "sender_error");
@@ -52,6 +54,8 @@ describe('event types', function() {
         assert.equal(rhea.ConnectionEvents.connectionClose, "connection_close");
         assert.equal(rhea.ConnectionEvents.connectionError, "connection_error");
         assert.equal(rhea.ConnectionEvents.connectionOpen, "connection_open");
+        assert.equal(rhea.ConnectionEvents.protocolError, "protocol_error");
+        assert.equal(rhea.ConnectionEvents.error, "error");
         assert.equal(rhea.ConnectionEvents.disconnected, "disconnected");
         assert.equal(rhea.ConnectionEvents.settled, "settled");
         done();

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -571,6 +571,14 @@ export declare enum ConnectionEvents {
    */
   connectionError = "connection_error",
   /**
+   * @property {string} protocolError Raised when a protocol error is received on the underlying socket.
+   */
+  protocolError = "protocol_error",
+  /**
+   * @property {string} error Raised when an error is received on the underlying socket.
+   */
+  error = "error",
+  /**
    * @property {string} disconnected Raised when the underlying tcp connection is lost. The context
    * has a reconnecting property which is true if the library is attempting to automatically reconnect
    * and false if it has reached the reconnect limit. If reconnect has not been enabled or if the connection

--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -91,6 +91,10 @@ export declare enum ReceiverEvents {
    */
   receiverDrained  = 'receiver_drained',
   /**
+   * @property {string} receiverFlow Raised when a flow is received for receiver.
+   */
+  receiverFlow = "receiver_flow",
+  /**
    * @property {string} receiverError Raised when the remote peer closes the receiver with an
    * error. The context may also have an error property giving some information about the reason
    * for the error.
@@ -124,6 +128,10 @@ export declare enum SenderEvents {
    * is used up..
    */
   senderDraining = 'sender_draining',
+  /**
+   * @property {string} senderFlow Raised when a flow is received for sender.
+   */
+  senderFlow = "sender_flow",
   /**
    * @property {string} senderError Raised when the remote peer closes the sender with an
    * error. The context may also have an error property giving some information about the


### PR DESCRIPTION
- This [issue comment](https://github.com/amqp/rhea/issues/74#issuecomment-395165091) helped in adding the event names.
- Searched the library with `this.dispatch` and made sure all the events are covered.
- I think after this PR is merged, we should have documented all the possible events emitted by rhea.