### PR TITLE
Added connection id to all the log statements

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -180,7 +180,7 @@ var Connection = function (options, container) {
 Connection.prototype = Object.create(EventEmitter.prototype);
 Connection.prototype.constructor = Connection;
 Connection.prototype.dispatch = function(name) {
-    log.events('Connection got event: %s', name);
+    log.events('[%s] Connection got event: %s', this.options.id, name);
     if (this.listeners(name).length) {
         EventEmitter.prototype.emit.apply(this, arguments);
         return true;
@@ -231,7 +231,7 @@ Connection.prototype.connect = function () {
 
 Connection.prototype.reconnect = function () {
     this.scheduled_reconnect = undefined;
-    log.reconnect('reconnecting...');
+    log.reconnect('[%s] reconnecting...', this.options.id);
     this._reconnect();
     this._connect(this.options.connection_details(this.conn_established_counter));
     process.nextTick(this._process.bind(this));
@@ -491,7 +491,7 @@ Connection.prototype._disconnected = function (error) {
         if (!this.is_server && !this.transport_error && this.options.reconnect) {
             var delay = this.options.reconnect(this.conn_established_counter);
             if (delay >= 0) {
-                log.reconnect('Scheduled reconnect in ' + delay + 'ms');
+                log.reconnect('[%s] Scheduled reconnect in ' + delay + 'ms', this.options.id);
                 this.scheduled_reconnect = setTimeout(this.reconnect.bind(this), delay);
                 disconnect_ctxt.reconnecting = true;
             } else {

--- a/lib/container.js
+++ b/lib/container.js
@@ -38,7 +38,7 @@ var Container = function (options) {
 Container.prototype = Object.create(EventEmitter.prototype);
 Container.prototype.constructor = Container;
 Container.prototype.dispatch = function(name) {
-    log.events('Container got event: ' + name);
+    log.events('[%s] Container got event: ' + name, this.id);
     EventEmitter.prototype.emit.apply(this, arguments);
     if (this.listeners(name).length) {
         return true;

--- a/lib/link.js
+++ b/lib/link.js
@@ -53,7 +53,7 @@ var EventEmitter = require('events').EventEmitter;
 
 var link = Object.create(EventEmitter.prototype);
 link.dispatch = function(name) {
-    log.events('Link got event: %s', name);
+    log.events('[%s] Link got event: %s', this.connection.options.id, name);
     EventEmitter.prototype.emit.apply(this.observers, arguments);
     if (this.listeners(name).length) {
         EventEmitter.prototype.emit.apply(this, arguments);

--- a/lib/session.js
+++ b/lib/session.js
@@ -241,12 +241,12 @@ Outgoing.prototype.process = function() {
                     d.link.delivery_count++;
                     this.next_pending_delivery++;
                 } else {
-                    log.flow('Incoming window of peer preventing sending further transfers: remote_window=%d, remote_next_transfer_id=%d, next_transfer_id=%d',
-                        this.remote_window, this.remote_next_transfer_id, this.next_transfer_id);
+                    log.flow('[%s] Incoming window of peer preventing sending further transfers: remote_window=%d, remote_next_transfer_id=%d, next_transfer_id=%d',
+                        this.connection.options.id, this.remote_window, this.remote_next_transfer_id, this.next_transfer_id);
                     break;
                 }
             } else {
-                log.flow('Link has no credit');
+                log.flow('[%s] Link has no credit', this.connection.options.id);
                 break;
             }
         } else {
@@ -432,7 +432,7 @@ Session.prototype._reconnect = function() {
 };
 
 Session.prototype.dispatch = function(name) {
-    log.events('Session got event: %s', name);
+    log.events('[%s] Session got event: %s', this.connection.options.id, name);
     if (this.listeners(name).length) {
         EventEmitter.prototype.emit.apply(this, arguments);
         return true;
@@ -658,10 +658,10 @@ Session.prototype.on_attach = function (frame) {
 
 Session.prototype.on_disposition = function (frame) {
     if (frame.performative.role) {
-        log.events('Received disposition for outgoing transfers');
+        log.events('[%s] Received disposition for outgoing transfers', this.connection.options.id);
         this.outgoing.on_disposition(frame.performative);
     } else {
-        log.events('Received disposition for incoming transfers');
+        log.events('[%s] Received disposition for incoming transfers', this.connection.options.id);
         this.incoming.on_disposition(frame.performative);
     }
     this.connection._register();


### PR DESCRIPTION
- When we have multiple connections in the same process and are reviewing the log statements, it gets very confusing when the prefix `[connection-*]` is not present. It is hard to say which statement corresponds to which connection. This PR solves that problem.
- Note: Have not added the connection-id prefix to the log statements in message.js because wasn't able to get a reference to the connection object from that module. It is ok for now. Just wanted to document it here.