### PR TITLE
BREAKING(sasl): make sasl mechanisms asynchronous

### DIFF
--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -71,13 +71,13 @@ var PlainClient = function(username, password) {
     this.password = password;
 };
 
-PlainClient.prototype.start = function() {
+PlainClient.prototype.start = function(callback) {
     var response = new Buffer(1 + this.username.length + 1 + this.password.length);
     response.writeUInt8(0, 0);
     response.write(this.username, 1);
     response.writeUInt8(0, 1 + this.username.length);
     response.write(this.password, 1 + this.username.length + 1);
-    return response;
+    callback(undefined, response);
 };
 
 var AnonymousServer = function() {
@@ -94,11 +94,11 @@ var AnonymousClient = function(name) {
     this.username = name ? name : 'anonymous';
 };
 
-AnonymousClient.prototype.start = function() {
+AnonymousClient.prototype.start = function(callback) {
     var response = new Buffer(1 + this.username.length);
     response.writeUInt8(0, 0);
     response.write(this.username, 1);
-    return response;
+    callback(undefined, response);
 };
 
 var ExternalServer = function() {
@@ -114,12 +114,12 @@ var ExternalClient = function() {
     this.username = undefined;
 };
 
-ExternalClient.prototype.start = function() {
-    return '';
+ExternalClient.prototype.start = function(callback) {
+    callback(undefined, '');
 };
 
-ExternalClient.prototype.step = function() {
-    return '';
+ExternalClient.prototype.step = function(callback) {
+    callback(undefined, '');
 };
 
 var XOAuth2Client = function(username, token) {
@@ -127,7 +127,7 @@ var XOAuth2Client = function(username, token) {
     this.token = token;
 };
 
-XOAuth2Client.prototype.start = function() {
+XOAuth2Client.prototype.start = function(callback) {
     var response = new Buffer(this.username.length + this.token.length + 5 + 12 + 3);
     var count = 0;
     response.write('user=', count);
@@ -144,7 +144,7 @@ XOAuth2Client.prototype.start = function() {
     count += 1;
     response.writeUInt8(1, count);
     count += 1;
-    return response;
+    callback(response);
 };
 
 /**
@@ -228,25 +228,41 @@ SaslClient.prototype.on_sasl_mechanisms = function (frame) {
         var mech = frame.performative.sasl_server_mechanisms[i];
         var f = this.mechanisms[mech];
         if (f) {
-            this.mechanism = f();
+            this.mechanism = typeof f === 'function' ? f() : f;
             this.mechanism_name = mech;
         }
     }
     if (this.mechanism) {
-        var response = this.mechanism.start();
-        var init = {'mechanism':this.mechanism_name,'initial_response':response};
-        if (this.hostname) {
-            init.hostname = this.hostname;
+        var self = this;
+        this.mechanism.start(function (err, response) {
+            if (err) {
+                self.failed = true;
+                self.connection.sasl_failed('SASL mechanism init failed: ' + err);
+            } else {
+                var init = {'mechanism':self.mechanism_name,'initial_response':response};
+                if (self.hostname) {
+                    init.hostname = self.hostname;
+                }
+                self.transport.encode(frames.sasl_frame(frames.sasl_init(init).described()));
+                self.connection.output();
         }
-        this.transport.encode(frames.sasl_frame(frames.sasl_init(init).described()));
+        });
     } else {
         this.failed = true;
         this.connection.sasl_failed('No suitable mechanism; server supports ' + frame.performative.sasl_server_mechanisms);
     }
 };
 SaslClient.prototype.on_sasl_challenge = function (frame) {
-    var response = this.mechanism.step(frame.performative.challenge);
-    this.transport.encode(frames.sasl_frame(frames.sasl_response({'response':response}).described()));
+    var self = this;
+    this.mechanism.step(frame.performative.challenge, function (err, response) {
+        if (err) {
+            self.failed = true;
+            self.connection.sasl_failed('SASL mechanism challenge failed: ' + err);
+        } else {
+            self.transport.encode(frames.sasl_frame(frames.sasl_response({'response':response}).described()));
+            self.connection.output();
+        }
+    });
 };
 SaslClient.prototype.on_sasl_outcome = function (frame) {
     switch (frame.performative.code) {

--- a/typings/sasl.d.ts
+++ b/typings/sasl.d.ts
@@ -21,7 +21,7 @@ declare class PlainClient {
   username: string;
   password: string;
   constructor(username: string, password: string);
-  start(): Buffer;
+  start(callback: Function): void;
 }
 
 declare class AnonymousServer {
@@ -33,7 +33,7 @@ declare class AnonymousServer {
 declare class AnonymousClient {
   username: string;
   constructor(username: string);
-  start(): Buffer;
+  start(callback: Function): void;
 }
 
 declare class ExternalServer {
@@ -44,15 +44,15 @@ declare class ExternalServer {
 
 declare class ExternalClient {
   username?: string;
-  start(): "";
-  step(): ""
+  start(callback: Function): void;
+  step(callback: Function): void;
 }
 
 declare class XOAuth2Client {
   username: string;
   token: string;
   constructor(username: string, token: string);
-  start(): Buffer;
+  start(callback: Function): void;
 }
 
 declare class SaslServer {


### PR DESCRIPTION
Related to #110 

**not ready/complete yet**

this change allows a user of the library to pass an already instantiated SASL mechanism that could respond to SASL challenges in an asynchronous manner.

I'm running into a race condition that I don't know how to solve though:

the `SaslClient.has_writes_pending()` method is called while the SASL mechanism is still working on the response (before it calls the callback of line 256). This is true but since no frames are enqueued, nothing is sent. Then when the callback is called, it's too late and nothing is calling either has_writes_pending() or `SaslClient.write()`. makes me think i'm either not using the right pattern for asynchronism with the library. I do not understand how/why `has_writes_pending()` is called.
FYI I can make things work by calling `self.connection.output()` on line 262 so I'm guessing whatever loop/event is used to call `has_writes_pending()` (and subsequently `write()`) fires prematurely or should loop until a `write()` has actually happened if `has_write_pending()` returns true?



PS: still lacking tests - want to validate the pattern and make things work first.

[edit] clarification/additional info on the race condition.