### PR TITLE
fix(sasl): Added fix to handle single mechanism

### DIFF
--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -224,8 +224,14 @@ var SaslClient = function (connection, mechanisms, hostname) {
 };
 
 SaslClient.prototype.on_sasl_mechanisms = function (frame) {
-    for (var i = 0; this.mechanism === undefined && i < frame.performative.sasl_server_mechanisms.length; i++) {
-        var mech = frame.performative.sasl_server_mechanisms[i];
+    const frame_sasl_mechanisms = typeof frame.performative.sasl_server_mechanisms === 'undefined' || frame.performative.sasl_server_mechanisms === null
+        ? [] 
+        : !Array.isArray(frame.performative.sasl_server_mechanisms)
+            ? [ frame.performative.sasl_server_mechanisms ]
+            : frame.performative.sasl_server_mechanisms;
+     
+    for (var i = 0; this.mechanism === undefined && i < frame_sasl_mechanisms.length; i++) {
+        var mech = frame_sasl_mechanisms[i];
         var f = this.mechanisms[mech];
         if (f) {
             this.mechanism = typeof f === 'function' ? f() : f;


### PR DESCRIPTION
If the qpid server supports only single sasl mechanism, librray was failing as the `frame.performative.sasl_server_mechanisms` would of type string.
Converting it to array so that for loop will actually iterate over actual mechanism. Also added null check defaulting to an empty array to avoid failure or uncaught error
Closes: https://github.com/amqp/rhea/issues/165