### PR TITLE
AutoSettle received msg if remote settles it 

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ object that may contain any of the following fields:
     manage it directly.
   * autoaccept - Whether received messages should be automatically
     accepted. Defaults to true.
+  * autosettle - Whether received messages should be automatically
+    settled once the remote settles them. Defaults to true.
 
 Note: If the link doesn't specify a value for the credit_window and
 autoaccept options, the connection options are consulted followed by

--- a/lib/link.js
+++ b/lib/link.js
@@ -344,7 +344,7 @@ var Receiver = function (session, name, local_handle, opts) {
     if (this.get_option('autoaccept', true)) {
         this.observers.on('message', auto_accept);
     }
-    if (this.get_option('autosettle', true)) {
+    if (this.local.attach.rcv_settle_mode === 1 && this.get_option('autosettle', true)) {
         this.observers.on('settled', auto_settle);
     }
 };

--- a/lib/link.js
+++ b/lib/link.js
@@ -344,6 +344,9 @@ var Receiver = function (session, name, local_handle, opts) {
     if (this.get_option('autoaccept', true)) {
         this.observers.on('message', auto_accept);
     }
+    if (this.get_option('autosettle', true)) {
+        this.observers.on('settled', auto_settle);
+    }
 };
 Receiver.prototype = Object.create(link);
 Receiver.prototype.constructor = Receiver;

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -342,6 +342,11 @@ export interface ReceiverOptions extends LinkOptions {
    * @property {object} [target]  The target of a receiving link is the local identifier
    */
   target?: TargetTerminusOptions | string;
+  /**
+   * @property {boolean} [autosettle] Whether received messages should be automatically settled
+   * once the remote settles them. Defaults to `true`.
+   */
+  autosettle?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR attempts to fix #178

@grs A few questions
- Do you prefer the `autoSettle` option on the receiver to be false by default so as to not change existing behavior or keep to `true` as that is what would be ideally expected
- I am currently not adding a check of whether the receiver mode is first or second. If its first, then `delivery.settled` would already be `true`. Let me know if you prefer an explicit check and have this autoSettling happen only for second receiver mode
