### PR TITLE
Update typescript definitions 

### DIFF
--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -186,7 +186,7 @@ export declare interface types {
   wrap_symbolic_map(m: object): Typed;
   wrap_array(l: any, code: number, descriptors: any): Typed;
   wrap(o: any): Typed;
-  wrap_described(value: any, descriptor: string | number | Number): Typed;
+  wrap_described(value: any, descriptor: string | number | Number | Typed): Typed;
   wrap_message_id(o: any): any;
   described_nc(descriptor: any[] | any, o: any): any;
   described(descriptor: any, o: any): any;


### PR DESCRIPTION
fix(typings): fix wrap_described compiler error

This was observed during #189 (comment). So added `Typed` as acceptable input type