### PR TITLE
remove_all_sessions() to clean up connection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -738,6 +738,11 @@ Connection.prototype.remove_session = function (session) {
     delete this.local_channel_map[session.local.channel];
 };
 
+Connection.prototype.remove_all_sessions = function () {
+    this.remote_channel_map = {};
+    this.local_channel_map = {};
+};
+
 function delegate_to_session(name) {
     Connection.prototype['on_' + name] = function (frame) {
         var session = this.remote_channel_map[frame.channel];

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -651,6 +651,7 @@ export declare interface Connection extends EventEmitter {
   get_peer_certificate(): PeerCertificate | undefined;
   get_tls_socket(): Socket | undefined;
   remove_session(session: Session): void;
+  remove_all_sessions(): void;
 }
 
 export declare enum ConnectionEvents {


### PR DESCRIPTION
This PR adds a new function `remove_all_sessions` on the connection to clear the internal map for sessions as per 
https://github.com/amqp/rhea/issues/205#issuecomment-473615598

The intention is to provide a simple, single function to a consumer who doesn't want to re-connect the sessions and links on re-opening the connection. The alternative is for the consumer to keep track of all the sessions and links and then call `remove` on each of them

cc @grs, @amarzavery 