### PR TITLE
Export WS parameters from Rhea.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,6 +14,7 @@ export { filter as Filter } from "./filter"
 export { Container, ContainerOptions } from "./container";
 export { types as Types, Typed } from "./types";
 export { sasl as Sasl } from "./sasl";
+export { WebSocketImpl, WebSocketInstance } from "./ws";
 export {
   connect, create_container, filter, generate_uuid, id, message,
   options, get_option, sasl, sasl_server_mechanisms, string_to_uuid, types,


### PR DESCRIPTION
**Reference**: https://github.com/amqp/rhea/pull/214

Higher libraries don't have access to the Web Socket parameters, so this pr exports web socket parameters from Rhea.
cc: @grs @amarzavery  @bterlson @ramya-rao-a 