### PR TITLE
Update typings to show encode() returning Buffer

### DIFF
--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -68,10 +68,12 @@ export declare interface Sender extends link {
   /**
    * Sends a message
    * @param {Message | Buffer} msg The message to be sent. For default AMQP format msg parameter
-   * should be of type Message interface. For a custom format, the msg parameter should be a Buffer.
+   * should be of type Message interface. For a custom format, the msg parameter should be a Buffer
+   * and a valid value should be passed to the `format` argument.
    * @param {Buffer | string} [tag] The message tag if any.
-   * @param {number} [format] The message format. Usually it is zero. Specify this
-   * if a message with custom format needs to be sent.
+   * @param {number} [format] The message format. Specify this if a message with custom format needs
+   * to be sent. For example, sending multiple messages in a single batch needs the format `0x80013700`.
+   * Sending a simple encoded message should use the value `0`.
    * @returns {Delivery} Delivery
    */
   send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Delivery;

--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -72,7 +72,8 @@ export declare interface Sender extends link {
    * and a valid value should be passed to the `format` argument.
    * @param {Buffer | string} [tag] The message tag if any.
    * @param {number} [format] The message format. Specify this if a message with custom format needs
-   * to be sent. `0` implies the standard AMQP 1.0 defined format.
+   * to be sent. `0` implies the standard AMQP 1.0 defined format. If no value is provided, then the
+   * given message is assumed to be of type Message interface and encoded appropriately.
    * @returns {Delivery} Delivery
    */
   send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Delivery;

--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -72,8 +72,7 @@ export declare interface Sender extends link {
    * and a valid value should be passed to the `format` argument.
    * @param {Buffer | string} [tag] The message tag if any.
    * @param {number} [format] The message format. Specify this if a message with custom format needs
-   * to be sent. For example, sending multiple messages in a single batch needs the format `0x80013700`.
-   * Sending a simple encoded message should use the value `0`.
+   * to be sent. `0` implies the standard AMQP 1.0 defined format.
    * @returns {Delivery} Delivery
    */
   send(msg: Message | Buffer, tag?: Buffer | string, format?: number): Delivery;

--- a/typings/message.d.ts
+++ b/typings/message.d.ts
@@ -17,7 +17,7 @@ export interface message {
   sequence_section: (list: any) => any;
   data_sections: (data_elements: any) => any;
   sequence_sections: (lists: any) => any;
-  encode: (msg: any) => any;
+  encode: (msg: any) => Buffer;
   decode: (buffer: Buffer) => Message;
   are_outcomes_equivalent: (a: any, b: any) => boolean;
   is_received: (o: Readonly<DeliveryOutcome>) => boolean;


### PR DESCRIPTION
The current typings for the the `encode()` method shows that its return value is of type `any`.
This PR updates the type of the return value to `Buffer`, as that is what the `encode()` method does

Also, updated the docs for the `send()` method to clarify the role of `format` which decides who does the encoding: rhea or the caller


cc @amarzavery, @grs