### PR TITLE
fix(container): Expose `DistributionMode` to support receiverin types…

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -103,5 +103,9 @@ Container.prototype.ReceiverEvents = eventTypes.ReceiverEvents;
 Container.prototype.SenderEvents = eventTypes.SenderEvents;
 Container.prototype.SessionEvents = eventTypes.SessionEvents;
 Container.prototype.ConnectionEvents = eventTypes.ConnectionEvents;
+Container.prototype.DistributionMode = {
+    move: 'move',
+    copy: 'copy'
+};
 
 module.exports = new Container();


### PR DESCRIPTION
…cript application and in correlation with definition

`DistributionMode` was exposed in [connection definitions](https://github.com/amqp/rhea/blob/master/typings/connection.d.ts) but not in actual library resulting in ```TypeError: Cannot read property 'move' of undefined```

To avoid that exposing `DistributionMode` explicitly

Fixes #224  