### PR TITLE
update typings for `transport` option

### DIFF
--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -55,6 +55,10 @@ export interface ConnectionDetails {
    * @property {Function} connect The `connect` function of `"net"` or `"tls"` module.
    */
   connect?: Function;
+  /**
+   * @property {string} [transport] - The transport option.
+   */
+  transport?: "tls" | "ssl" | "tcp";
 }
 
 /**
@@ -88,7 +92,7 @@ export interface ConnectionOptions extends EndpointOptions {
    */
   port?: number;
   /**
-   * @property {string} [transport] - The transport option.
+   * @property {string} [transport] - The transport option. This is ignored if connection_details is set.
    */
   transport?: "tls" | "ssl" | "tcp";
   /**


### PR DESCRIPTION
`transport` seems to be ignored at the connect options level when I use the `connection_details` method.  I have not tried connecting without the `connection_details` method, as I have a clustered broker and am using this method for failover.

Do these changes make sense?