### PR TITLE
Added sender link and receiver link stream objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 package-lock.json
 .env
+.idea

--- a/README.md
+++ b/README.md
@@ -324,6 +324,12 @@ autoaccept options, the connection options are consulted followed by
 the container options. The default is used only if an option is not
 specified at any level.
 
+##### open_receiver_stream(address|options)
+
+Like the open_receiver method, establishes a link over which messages
+can be received, but instead returns a Readable stream object that wraps
+the receiver link inside it.
+
 ##### open_sender(address|options)
 
 Establishes a link over which messages can be sent and returns a <a
@@ -353,6 +359,12 @@ Note: If the link doesn't specify a value for the autosettle option,
 the connection options are consulted followed by the container
 options. The default is used only if an option is not specified at any
 level.
+
+##### open_sender_stream(address|options)
+
+Like the open_sender method, link over which messages can be sent,
+but instead returns a Writable stream object that wraps the sender
+link inside it.
 
 ##### send(message)
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,6 +23,8 @@ var util = require('./util.js');
 var EndpointState = require('./endpoint.js');
 var Session = require('./session.js');
 var Transport = require('./transport.js');
+var SenderStream = require('./stream').SenderStream;
+var ReceiverStream = require('./stream').ReceiverStream;
 
 var fs = require('fs');
 var os = require('os');
@@ -379,6 +381,12 @@ Connection.prototype.attach_sender = function (options) {
 };
 Connection.prototype.open_sender = Connection.prototype.attach_sender;//alias
 
+Connection.prototype.attach_sender_stream = function (options) {
+    var senderLink = this.attach_sender(options);
+    return new SenderStream(senderLink, options);
+};
+Connection.prototype.open_sender_stream = Connection.prototype.attach_sender_stream;//alias
+
 Connection.prototype.attach_receiver = function (options) {
     if (this.get_option('tcp_no_delay', true) && this.socket.setNoDelay) {
         this.socket.setNoDelay(true);
@@ -386,6 +394,12 @@ Connection.prototype.attach_receiver = function (options) {
     return this.session_policy.get_session().attach_receiver(options);
 };
 Connection.prototype.open_receiver = Connection.prototype.attach_receiver;//alias
+
+Connection.prototype.attach_receiver_stream = function (options) {
+    var receiverLink = this.attach_receiver(options);
+    return new ReceiverStream(receiverLink);
+};
+Connection.prototype.open_receiver_stream = Connection.prototype.attach_receiver_stream;//alias
 
 Connection.prototype.get_option = function (name, default_value) {
     if (this.options[name] !== undefined) return this.options[name];

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var util = require('util');
+var Readable = require('stream').Readable;
+var Writable = require('stream').Writable;
+
+var ReceiverStream = function (receiverLink) {
+    var highWaterMark = receiverLink.get_option('credit_window', 1000);
+    this.link = receiverLink;
+    this.link.setMaxListeners(0);
+    this.setMaxListeners(0);
+    Readable.call(this, {objectMode: true, highWaterMark: highWaterMark});
+
+    this.link.on('message', this._processMessage.bind(this));
+};
+util.inherits(ReceiverStream, Readable);
+ReceiverStream.prototype._read = function (size) {
+    if (this.link.credit <= 0) {
+        this.link.add_credit(size);
+    }
+};
+ReceiverStream.prototype._processMessage = function (content) {
+    if (content && !this.push(content)) {
+        return this.link.set_credit_window(0);
+    }
+};
+
+var SenderStream = function (senderLink, options) {
+    options = options || {};
+    var highWaterMark = options.highWaterMark || 1000;
+    this.link = senderLink;
+    this.link.setMaxListeners(0);
+    this.setMaxListeners(0);
+    Writable.call(this, {objectMode: true, highWaterMark: highWaterMark});
+};
+util.inherits(SenderStream, Writable);
+SenderStream.prototype._write = function (chunk, encoding, callback) {
+    var delivery = this.link.send(chunk);
+    var onSettled = function () {
+        if (delivery.settled) {
+            callback();
+        } else {
+            delivery.link.once('settled', onSettled);
+        }
+    };
+    delivery.link.once('settled', onSettled);
+};
+
+module.exports = { 'ReceiverStream': ReceiverStream, 'SenderStream': SenderStream };

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -1,0 +1,80 @@
+import * as rhea from "../";
+import {Server} from "net";
+import * as assert from "assert";
+import {Readable} from "stream";
+import {Message} from "../";
+
+describe('stream', function () {
+    var server: rhea.Container,
+        client: rhea.Container,
+        listener: Server;
+
+    beforeEach(function (done: Function) {
+        server = rhea.create_container();
+        client = rhea.create_container();
+        listener = server.listen({port: 0});
+        listener.on('listening', function () {
+            done();
+        });
+    });
+
+    afterEach(function () {
+        listener.close();
+    });
+
+    it('open sender stream', function (done: Function) {
+        let receiveCounter = 0;
+        let sendCounter = 0;
+        let pauseCounter = 0;
+        server.on('message', function (context) {
+            if (receiveCounter < 1000) {
+                assert.equal(context.message.body, 'mississippi_' + (++receiveCounter));
+            } else {
+                assert.equal(context.message.body, 'enough_mississippi');
+                senderStream.link.connection.close();
+            }
+        });
+        client.once('sendable', function () {
+            do {
+                readable.push({body: 'mississippi_' + ++sendCounter});
+            } while (sendCounter < 1000);
+            readable.push({body: 'enough_mississippi'});
+        });
+        client.on('connection_close', function () {
+            assert.equal(pauseCounter, 200);
+            done();
+        });
+        const senderStream = client.connect(listener.address()).open_sender_stream({highWaterMark: 5});
+        const readable = new Readable({highWaterMark: 1000, objectMode: true, read() {}})
+            .on('pause', () => pauseCounter++);
+        readable.pipe(senderStream);
+    });
+
+    it('open receiver stream', function (done: Function) {
+        let receiveCounter = 0;
+        let sendCounter = 0;
+        client.on('message', function(context) {
+            assert.equal(context.message.body, 'settle-me');
+        });
+        client.on('connection_close', function () {
+            done();
+        });
+        let receiverStream = client.connect(listener.address()).attach_receiver_stream({credit_window: 5})
+            .on('data', function (context: {message: Message}) {
+                if (receiveCounter < 1000) {
+                    assert.equal(context.message.body, 'mississippi_' + (++receiveCounter));
+                } else {
+                    assert.equal(context.message.body, 'enough_mississippi');
+                    receiverStream.link.connection.close();
+                }
+            });
+        server.once('sendable', function (context) {
+            receiverStream.link.on('receiver_open', function () {
+                do {
+                    context.sender.send({body: 'mississippi_' + ++sendCounter});
+                } while (sendCounter < 1000);
+                context.sender.send({body: 'enough_mississippi'});
+            });
+        });
+    });
+});

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -10,6 +10,7 @@ import { EventEmitter } from "events";
 import { Container } from "./container";
 import { PeerCertificate } from "tls";
 import { ConnectionError } from "./errors";
+import {ReceiverStream, SenderStream} from "./stream";
 
 /**
  * Describes the signature of the event handler for any event emitted by rhea.
@@ -101,7 +102,7 @@ export interface ConnectionOptions extends EndpointOptions {
    * provided, it will be used in the `open` frame to let the peer know about the container id.
    * However, the associated container object would still be the same container object from
    * which the connection is being created.
-   * 
+   *
    * The `"container_id"` is how the peer will identify the 'container' the connection is being
    * established from. The container in AMQP terminology is roughly analogous to a process.
    * Using a different container id on connections from the same process would cause the peer to
@@ -354,7 +355,7 @@ export interface SenderOptions extends LinkOptions {
   autosettle?: boolean;
   /**
    * @property {object} target  - The target to which messages are sent.
-   * 
+   *
    * If the target is set to `{}` no target address will be associated with the sender; the peer
    * may use the `to` field on each individual message to handle it correctly in that case.
    * This is useful where maintaining or setting up a sender for each target address is
@@ -365,6 +366,18 @@ export interface SenderOptions extends LinkOptions {
    * @property {object} [source]  The source of a sending link is the local identifier.
    */
   source?: Source | string;
+}
+
+/**
+ * Defines the options that can be set while creating the Sender (link) and its wrapper stream.
+ * @interface SenderStreamOptions
+ * @extends SenderOptions
+ */
+export interface SenderStreamOptions extends SenderOptions {
+  /**
+   * @property {number} highWaterMark - The writable stream high water mark value.
+   */
+  highWaterMark?: number
 }
 
 /**
@@ -391,7 +404,7 @@ export interface MessageAnnotations {
  * Describes the delivery annotations. It is used for delivery-specific non-standard
  * properties at the head of the message. It conveys information from the sending
  * peer to the receiving peer. This is the base interface for Delivery Annotations.
- * 
+ *
  * @interface DeliveryAnnotations
  */
 export interface DeliveryAnnotations {
@@ -617,8 +630,12 @@ export declare interface Connection extends EventEmitter {
   reconnect(): Connection;
   attach_sender(options?: SenderOptions | string): Sender;
   open_sender(options?: SenderOptions | string): Sender;
+  attach_sender_stream(options?: SenderStreamOptions | string): SenderStream;
+  open_sender_stream(options?: SenderStreamOptions | string): SenderStream;
   attach_receiver(options?: ReceiverOptions | string): Receiver;
   open_receiver(options?: ReceiverOptions | string): Receiver;
+  attach_receiver_stream(options?: ReceiverOptions | string): ReceiverStream;
+  open_receiver_stream(options?: ReceiverOptions | string): ReceiverStream;
   get_option(name: string, default_value: any): any;
   send(msg: Message): Delivery;
   get_error(): ConnectionError | undefined;

--- a/typings/stream.d.ts
+++ b/typings/stream.d.ts
@@ -1,0 +1,10 @@
+import { Readable, Writable } from "stream";
+import { Receiver, Sender } from "./link";
+
+export declare interface ReceiverStream extends Readable {
+    link: Receiver
+}
+
+export declare interface SenderStream extends Writable {
+    link: Sender
+}


### PR DESCRIPTION
Hi,
On one of the projects I'm working on I decided to move from ampq10 to rhea.
Unfortunately rhea doesn't provide receiver and sender stream interface, like amp10 does.

So, I forked off rhea, implemented what I was missing and now I offer the result.

* New stream.js exports ReceiverStream and SenderStream.
* Expanded Connection interface with methods: attach_receiver_stream and attach_sender_stream, and their aliases open_*.
* Added and edited typings.
* Added tests.