### PR TITLE
Resets abort_idle field when calling connection.connect

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -287,6 +287,7 @@ Connection.prototype._reset_remote_state = function() {
 
 Connection.prototype.connect = function () {
     this.is_server = false;
+    this.abort_idle = false;
     this._reset_remote_state();
     this._connect(this.options.connection_details(this.conn_established_counter));
     this.open();


### PR DESCRIPTION
Fixes #266 

I wasn't sure how to write a test for this given I would need to trigger the idle_time_out but happy to try if you can give me some pointers!

I did run npm pack and tested with my sample code and with my library to confirm the change does allow me to reconnect.