### PR TITLE
add tls options in ConnectionOptions

### DIFF
--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -189,6 +189,28 @@ export interface ConnectionOptions extends EndpointOptions {
    * from peer should not prevent reconnect (by default this only includes `"amqp:connection:forced"`).
    */
   non_fatal_errors?: string[];
+  /**
+   * @property {string} [key] The private key of the certificate to be used with tls connection option
+   */
+  key?: string,
+  /**
+   * @property {string} [cert] The certificate to be used with tls connection option
+   */
+  cert?: string,
+  /**
+   * @property {string} [ca] The CA certificate used for signing certificate to be used with tls connection option
+   */
+  ca?: string,
+  /**
+   * @property {boolean} [requestCert] Flag to indicate client authentication to be used with tls connection option
+   * This is used in opening socket by nodejs
+   */
+  requestCert?: boolean,
+  /**
+   * @property {boolean} [rejectUnauthorized] Flag to indicate if certificate is self signed to be used with tls connection option
+   * This is used in opening socket by nodejs
+   */
+  rejectUnauthorized?: boolean
 }
 
 /**


### PR DESCRIPTION
fixes #272 

I would prefer to incapsulate these options under `tls` object in `ConnectionOptions` but that would require code change in `connection.js` to read them. @grs, if this seems feasible I can go that route.