### PR TITLE
Setreconnect

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -173,6 +173,25 @@ function connection_fields(fields) {
     return o;
 }
 
+function set_reconnect(reconnect, connection) {
+    if (typeof reconnect === 'boolean' && reconnect) {
+        var initial = connection.get_option('initial_reconnect_delay', 100);
+        var max = connection.get_option('max_reconnect_delay', 60000);
+        connection.options.reconnect = restrict(
+            connection.get_option('reconnect_limit'),
+            backoff(initial, max)
+        );
+    } else if (typeof reconnect === 'number') {
+        var fixed = connection.options.reconnect;
+        connection.options.reconnect = restrict(
+            connection.get_option('reconnect_limit'),
+            function() {
+                return fixed;
+            }
+        );
+    }
+}
+
 var conn_counter = 1;
 
 var Connection = function (options, container) {
@@ -200,14 +219,7 @@ var Connection = function (options, container) {
         this.options.connection_details = function() { return connection_details(self.options); };
     }
     var reconnect = this.get_option('reconnect', true);
-    if (typeof reconnect === 'boolean' && reconnect) {
-        var initial = this.get_option('initial_reconnect_delay', 100);
-        var max = this.get_option('max_reconnect_delay', 60000);
-        this.options.reconnect = restrict(this.get_option('reconnect_limit'), backoff(initial, max));
-    } else if (typeof reconnect === 'number') {
-        var fixed = this.options.reconnect;
-        this.options.reconnect = restrict(this.get_option('reconnect_limit'), function () { return fixed; });
-    }
+    set_reconnect(reconnect, this);
     this.registered = false;
     this.state = new EndpointState();
     this.local_channel_map = {};
@@ -299,6 +311,10 @@ Connection.prototype.reconnect = function () {
     this._connect(this.options.connection_details(this.conn_established_counter));
     process.nextTick(this._process.bind(this));
     return this;
+};
+
+Connection.prototype.set_reconnect = function (reconnect) {
+    set_reconnect(reconnect, this);
 };
 
 Connection.prototype._connect = function (details) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -174,13 +174,17 @@ function connection_fields(fields) {
 }
 
 function set_reconnect(reconnect, connection) {
-    if (typeof reconnect === 'boolean' && reconnect) {
-        var initial = connection.get_option('initial_reconnect_delay', 100);
-        var max = connection.get_option('max_reconnect_delay', 60000);
-        connection.options.reconnect = restrict(
-            connection.get_option('reconnect_limit'),
-            backoff(initial, max)
-        );
+    if (typeof reconnect === 'boolean') {
+        if (reconnect) {
+            var initial = connection.get_option('initial_reconnect_delay', 100);
+            var max = connection.get_option('max_reconnect_delay', 60000);
+            connection.options.reconnect = restrict(
+                connection.get_option('reconnect_limit'),
+                backoff(initial, max)
+            );
+        } else {
+            connection.options.reconnect = false;
+        }
     } else if (typeof reconnect === 'number') {
         var fixed = connection.options.reconnect;
         connection.options.reconnect = restrict(

--- a/test/reconnect.ts
+++ b/test/reconnect.ts
@@ -244,6 +244,30 @@ describe('reconnect', function() {
             socket.end();
         });
     });
+    it('can set reconnect after connect', function(done: Function) {
+        this.slow(1200);
+        var container: rhea.Container = rhea.create_container();
+        var count: number = 0;
+        var disconnects: number = 0;
+        var c: rhea.Connection = container.connect(
+            add(listener.address(), 'reconnect', false)
+        );
+        c.on("disconnected", function(context) {
+            disconnects++;
+        });
+        c.on("connection_open", function(context) {
+            c.set_reconnect(true);
+            count++;
+            assert.equal(context.connection.remote.open.hostname, "test" + count);
+            if (count === 1) {
+                socket.end();
+            } else {
+                assert.equal(disconnects, 1);
+                context.connection.close();
+                done();
+            }
+        });
+    });
 });
 
 describe('non-fatal error', function() {


### PR DESCRIPTION
This allows setting reconnect behaviour after a connection is established.
Currently, if a connection is created with options.reconnect: false, rhea's internal reconnect behaviour cannot be changed to reconnect: true. 
That is because the default reconnect behaviour is set during the connection constructor where connection.options.reconnect is set to a private internal function.

This patch does the following:
- creates an internal function that sets the existing reconnect behaviour
- calls the new internal function in the connection constructor
- exposes a new function prototype connection.set_reconnect(reconnect) that calls the new internal function
- creates a new reconnect test to verify that calling connection.set_reconnect(true) works

Usage:
Set options.reconnect to false during the initial connect.
After the connection opens, call connection.set_reconnect(true)
or
Set options.reconnect to true during the initial connect
After the connection opens, call connection.set_reconnect(false). This is equivalent to setting connection.options.reconnect = false and is included for completeness.

