### PR TITLE
fixes: destroy socket after idle timeout

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -345,6 +345,9 @@ Connection.prototype.abort_socket = function (socket) {
         this.socket.removeAllListeners('data');
         this.socket.removeAllListeners('error');
         this.socket.removeAllListeners('end');
+        if (typeof this.socket.destroy === 'function') {
+            this.socket.destroy();
+        }
         this._disconnected();
     }
 };


### PR DESCRIPTION
**Describe the bug**
When a receiver hits the `idle_time_out` period, rhea aborts the socket by calling `this.socket.end()` and removing listeners. What we're seeing in some scenarios is that the readable part of the socket isn't closed, causing the process to either hang for a long period of time, or to eventually crash from an uncaught exception. The uncaught exception happens when the readable part of the socket emits an error because the error event handlers have all been removed.

**Potential fix**
In this PR, I've added a call to `this.socket.destroy()` when aborting a socket. This will ensure that the readable portion of the socket is also closed.

**Steps to reproduce**
I've created a repository to make it easy to reproduce this issue:
https://github.com/chradek/rhea-promise-error-sample

In the sample, the script starts a receiver, waits 1 second for it to connect, then disables inbound traffic from the service by invoking an iptables command. After 2 minutes, the script removes the iptables rule. At this point after a minute or so, the script will throw an uncaught `ECONNRESET` error.

I chose to disable inbound traffic from the service for 2 minutes since that seems to reliably trigger the error with my docker container. If I change the duration to be much smaller or much longer, instead I've seen the process appears to hang (it's possible it eventually closes/throws an error, but I did not wait long enough to see.)