### PR TITLE
Update dev dependencies to resolve audit issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@types/mocha": "^5.2.0",
         "@types/node": "^8.0.37",
         "browserify": "",
-        "eslint": "^6.8.0",
+        "eslint": "^4.19.1",
         "istanbul": "1.1.0-alpha.1",
         "minimist": "",
         "mocha": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
         "debug": "0.8.0 - 3.5.0"
     },
     "devDependencies": {
-        "@types/node": "^8.0.37",
         "@types/debug": "^0.0.30",
         "@types/mocha": "^5.2.0",
+        "@types/node": "^8.0.37",
         "browserify": "",
-        "eslint": "^4.19.1",
+        "eslint": "^6.8.0",
         "istanbul": "1.1.0-alpha.1",
         "minimist": "",
-        "mocha": "^3.0.0",
-        "uglify-js": "",
+        "mocha": "^7.1.2",
         "require-self": "^0.2.1",
-        "ws": "^6.0.0",
+        "ts-node": "^8.10.1",
         "typescript": "^3.0.1",
-        "ts-node": "^7.0.0"
+        "uglify-js": "",
+        "ws": "^6.0.0"
     },
     "scripts": {
         "lint": "eslint lib/*.js",


### PR DESCRIPTION
Found the below warning when recently running `npm i` for this project

<img width="492" alt="Screen Shot 2020-05-06 at 7 33 51 PM" src="https://user-images.githubusercontent.com/16890566/81248117-88d74400-8fd0-11ea-9275-81df9b2841ee.png">

Though the fixes are in dev dependencies only and so will not affect the resulting package, thought it would be nice not to alarm any new comer to the project :)

This PR has the resulting changes from running `npm audit`