### PR TITLE
Call `this.socket.removeAllListeners()` only when defined

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -342,9 +342,11 @@ Connection.prototype.abort_socket = function (socket) {
     if (socket === this.socket) {
         log.io('[%s] aborting socket', this.options.id);
         this.socket.end();
-        this.socket.removeAllListeners('data');
-        this.socket.removeAllListeners('error');
-        this.socket.removeAllListeners('end');
+        if (this.socket.removeAllListeners) {
+            this.socket.removeAllListeners('data');
+            this.socket.removeAllListeners('error');
+            this.socket.removeAllListeners('end');
+        }
         if (typeof this.socket.destroy === 'function') {
             this.socket.destroy();
         }


### PR DESCRIPTION
**[lib/connection.js file]**
![image](https://user-images.githubusercontent.com/10452642/84090135-b0da0e80-a9a5-11ea-881e-b4ed6f1cbd7a.png)


At the highlighted line from the above screenshot, `this.socket.removeAllListeners` is a function in node but is `undefined` in the browser.

Since it is undefined in the browsers, a TypeError is thrown saying 
"`this.socket.removeAllListeners` is not a function."

Valid code path where this is encountered:
 `_connection.idle()` triggers a settimeout, which invokes the abort_socket function, resulting in a TypeError in the browsers.

References - https://github.com/Azure/azure-sdk-for-js/issues/8672