### PR TITLE
Make ConnectionError.connection not enumerable

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,7 +38,7 @@ function ConnectionError(message, condition, connection) {
     this.name = 'ConnectionError';
     this.condition = condition;
     this.description = message;
-    this.connection = connection;
+    Object.defineProperty(this, 'connection', { value: connection, enumerable: false });
 }
 
 util.inherits(ConnectionError, Error);


### PR DESCRIPTION
Pino logger logs enumerable Error object members.

The connection with all deliveries and message content is too large to be logged. It hides the actual error.
