### PR TITLE
forward sender and receiver options to service link creation

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -457,10 +457,16 @@ Session.prototype.output = function (frame, payload) {
 };
 
 Session.prototype.create_sender = function (name, opts) {
+    if (!opts) {
+        opts = this.get_option('sender_options', {});
+    }
     return this.create_link(name, link.Sender, opts);
 };
 
 Session.prototype.create_receiver = function (name, opts) {
+    if (!opts) {
+        opts = this.get_option('receiver_options', {});
+    }
     return this.create_link(name, link.Receiver, opts);
 };
 


### PR DESCRIPTION
## Description of changes
This PR updates sender/receiver creation to use the `sender_options`/`receiver_options` from the container if they were specified.

Previously this worked fine when creating sender/receiver links as a client, but did not work when creating sender/receiver links as a service.

/cc @grs 