### PR TITLE
Make LinkError.link and SessionError.session not enumerable

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,7 +38,7 @@ function ConnectionError(message, condition, connection) {
     this.name = 'ConnectionError';
     this.condition = condition;
     this.description = message;
-    Object.defineProperty(this, 'connection', { value: connection, enumerable: false });
+    Object.defineProperty(this, 'connection', { value: connection });
 }
 
 util.inherits(ConnectionError, Error);

--- a/lib/link.js
+++ b/lib/link.js
@@ -45,7 +45,7 @@ function LinkError(message, condition, link) {
     this.message = message;
     this.condition = condition;
     this.description = message;
-    this.link = link;
+    Object.defineProperty(this, 'link', { value: link });
 }
 require('util').inherits(LinkError, Error);
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -31,7 +31,7 @@ function SessionError(message, condition, session) {
     this.message = message;
     this.condition = condition;
     this.description = message;
-    this.session = session;
+    Object.defineProperty(this, 'session', { value: session });
 }
 require('util').inherits(SessionError, Error);
 


### PR DESCRIPTION
Pino logger logs enumerable Error object members. The context properties
with all deliveries and message content are too large to be logged.

The ConnectionError.connection that was not enumerable before defined
enumerable unnecessarily with default value.

The earlier PR #310 failed to address similar properties on these other errors.
