### PR TITLE
[question] `timestamp` deserialization (can we deserialize directly to `Date`)?

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -266,6 +266,11 @@ function read_long(buffer, offset) {
     }
 }
 
+function read_timestamp(buffer, offset) {
+    const l = read_long(buffer, offset);
+    return new Date(l);
+}
+
 define_type('Null', 0x40, undefined, null);
 define_type('Boolean', 0x56, buffer_uint8_ops());
 define_type('True', 0x41, undefined, true);
@@ -290,7 +295,7 @@ define_type('Decimal32', 0x74);
 define_type('Decimal64', 0x84);
 define_type('Decimal128', 0x94);
 define_type('CharUTF32', 0x73, buffer_uint32be_ops());
-define_type('Timestamp', 0x83, {'write':write_long, 'read':read_long});//TODO: convert to/from Date
+define_type('Timestamp', 0x83, {'write':write_long, 'read':read_timestamp});
 define_type('Uuid', 0x98);//TODO: convert to/from stringified form?
 define_type('Vbin8', 0xa0);
 define_type('Vbin32', 0xb0);

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -243,17 +243,29 @@ describe('message content', function() {
         assert.equal(message.correlation_id, 'correlate-me');
         assert.equal(message.content_type, 'text');
         assert.equal(message.content_encoding, 'ascii');
-        assert.equal(message.absolute_expiry_time, 123456789);
-        assert.equal(message.creation_time, 987654321);
+        assert.equal(asNumber(message.absolute_expiry_time), 123456789);
+        assert.equal(asNumber(message.creation_time), 987654321);
         assert.equal(message.group_id, 'my-group');
         assert.equal(message.group_sequence, 77);
         assert.equal(message.reply_to_group_id, 'still-my-group');
         assert.equal(message.durable, true);
         assert.equal(message.priority, 3);
-        assert.equal(message.ttl, 123456789);
+        assert.equal(asNumber(message.ttl), 123456789);
         assert.equal(message.first_acquirer, false);
         assert.equal(message.delivery_count, 8);
     }));
+
+    function asNumber(timestamp: number | Date | undefined): number {
+        if (timestamp == null) {
+            return 0;
+        } else if (typeof timestamp === "number") {
+            return timestamp;
+        } else {
+            return timestamp.getTime();
+        }
+    }
+
+
     it('set header and properties directly', transfer_test({
         message_id:'my-id',
         user_id:'my-user',
@@ -282,14 +294,14 @@ describe('message content', function() {
         assert.equal(message.correlation_id, 'correlate-me');
         assert.equal(message.content_type, 'text');
         assert.equal(message.content_encoding, 'ascii');
-        assert.equal(message.absolute_expiry_time, 123456789);
-        assert.equal(message.creation_time, 987654321);
+        assert.equal(asNumber(message.absolute_expiry_time), 123456789);
+        assert.equal(asNumber(message.creation_time), 987654321);
         assert.equal(message.group_id, 'my-group');
         assert.equal(message.group_sequence, 77);
         assert.equal(message.reply_to_group_id, 'still-my-group');
         assert.equal(message.durable, true);
         assert.equal(message.priority, 3);
-        assert.equal(message.ttl, 123456789);
+        assert.equal(asNumber(message.ttl), 123456789);
         assert.equal(message.first_acquirer, false);
         assert.equal(message.delivery_count, 8);
     }));

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -250,7 +250,7 @@ describe('message content', function() {
         assert.equal(message.reply_to_group_id, 'still-my-group');
         assert.equal(message.durable, true);
         assert.equal(message.priority, 3);
-        assert.equal(asNumber(message.ttl), 123456789);
+        assert.equal(message.ttl, 123456789);
         assert.equal(message.first_acquirer, false);
         assert.equal(message.delivery_count, 8);
     }));
@@ -301,7 +301,7 @@ describe('message content', function() {
         assert.equal(message.reply_to_group_id, 'still-my-group');
         assert.equal(message.durable, true);
         assert.equal(message.priority, 3);
-        assert.equal(asNumber(message.ttl), 123456789);
+        assert.equal(message.ttl, 123456789);
         assert.equal(message.first_acquirer, false);
         assert.equal(message.delivery_count, 8);
     }));

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -459,11 +459,11 @@ export interface MessageProperties {
   /**
    * @property {number} [absolute_expiry_time] The time when this message is considered expired.
    */
-  absolute_expiry_time?: number | Date;
+  absolute_expiry_time?: Date;
   /**
    * @property {number} [creation_time] The time this message was created.
    */
-  creation_time?: number | Date;
+  creation_time?: Date;
   /**
    * @property {string} [group_id] The group this message belongs to.
    */

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -505,7 +505,7 @@ export interface MessageHeader {
   /**
    * @property {number} [ttl] time to live in ms.
    */
-  ttl?: number | Date;
+  ttl?: number;
   /**
    * @property {boolean} [durable] Specifies durability requirements.
    */

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -459,11 +459,11 @@ export interface MessageProperties {
   /**
    * @property {number} [absolute_expiry_time] The time when this message is considered expired.
    */
-  absolute_expiry_time?: number;
+  absolute_expiry_time?: number | Date;
   /**
    * @property {number} [creation_time] The time this message was created.
    */
-  creation_time?: number;
+  creation_time?: number | Date;
   /**
    * @property {string} [group_id] The group this message belongs to.
    */
@@ -505,7 +505,7 @@ export interface MessageHeader {
   /**
    * @property {number} [ttl] time to live in ms.
    */
-  ttl?: number;
+  ttl?: number | Date;
   /**
    * @property {boolean} [durable] Specifies durability requirements.
    */


### PR DESCRIPTION
I had a request recently to deserialize application_properties, when they are serialized as `timestamp` (setting a property with a `Date` instance will do that). Today a `timestamp` is deserialized as a `number`.

Looking a bit deeper it looks like rhea does know enough (via the type in the AMQP message) to deserialize the property into a `Date`. I hacked this into a PR and it's clear that it would be a backwards incompatible change if it was the default since the underlying type of the object will have changed and having at type union (as I've added) will still break people.

Line 293 in types.js actually had a TODO comment indicating it was desirable to translate the underlying field into `Date`. Interestingly serialization of a Date _does_ already work. I'm guessing there are some interesting edge cases or other ramifications and that's why the deserialization into date was marked as `TODO`.

I'd be willing to do some more work here, but I just wanted to start a conversation and see what might be involved here.