### PR TITLE
#345 Fix: Safely represent buffer in error messages

### DIFF
--- a/lib/frames.js
+++ b/lib/frames.js
@@ -26,7 +26,8 @@ frames.read_header = function(buffer) {
     var header = {};
     var name = buffer.toString('ascii', 0, offset);
     if (name !== 'AMQP') {
-        throw new errors.ProtocolError('Invalid protocol header for AMQP ' + name);
+        // output name in hex (null-bytes can be tough to deal with in ascii)
+        throw new errors.ProtocolError('Invalid protocol header for AMQP: ' + buffer.toString('hex', 0, offset));
     }
     header.protocol_id = buffer.readUInt8(offset++);
     header.major = buffer.readUInt8(offset++);


### PR DESCRIPTION
This change makes log output containing `rhea` errors compatible with PostgreSQL.

Fixes #345