### PR TITLE
[bugfix] fixes TypeError: _process of undefined

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -294,8 +294,9 @@ Connection.prototype._reset_remote_state = function() {
     this.remote = {};
     //reset sessions:
     this.remote_channel_map = {};
-    for (var k in this.local_channel_map) {
-        this.local_channel_map[k]._reconnect();
+    var localChannelMap = this.local_channel_map;
+    for (var k in localChannelMap) {
+        localChannelMap[k]._reconnect();
     }
 };
 
@@ -729,8 +730,9 @@ Connection.prototype._process = function () {
         if (this.state.need_open()) {
             this._write_open();
         }
-        for (var k in this.local_channel_map) {
-            this.local_channel_map[k]._process();
+        var localChannelMap = this.local_channel_map;
+        for (var k in localChannelMap) {
+            localChannelMap[k]._process();
         }
         if (this.state.need_close()) {
             this._write_close();
@@ -798,9 +800,18 @@ Connection.prototype.remove_session = function (session) {
 };
 
 Connection.prototype.remove_all_sessions = function () {
-    this.remote_channel_map = {};
-    this.local_channel_map = {};
+    clearObject(this.remote_channel_map);
+    clearObject(this.local_channel_map);
 };
+
+function clearObject(obj) {
+    for (var k in obj) {
+        if (!Object.prototype.hasOwnProperty.call(obj, k)) {
+            continue;
+        }
+        delete obj[k];
+    }
+}
 
 function delegate_to_session(name) {
     Connection.prototype['on_' + name] = function (frame) {


### PR DESCRIPTION
Fixes #286 

We were finally able to see this issue occur locally and it appears to be caused by a race condition when:
- `_process()` is called on a `Session`
- A `disconnected` event is emitted synchronously when `_process()` is called
- `Connection.remove_all_sessions` is invoked while there are still Sessions to iterate over in `_process`.

I've written a detailed explanation in the Azure SDK repo here: https://github.com/Azure/azure-sdk-for-js/issues/13500#issuecomment-850530283

The short version is this. Calling `remove_all_sessions` replaces the `this.local_channel_map` with a new object. In the Azure SDK for Service Bus and Event Hubs, we call `remove_all_sessions` when we receive a `disconnected` event. This causes the object referenced by `this.local_channel_map` inside the `Connection.prototype._process` for loop to be different than the object referenced by `this.local_channel_map` in the for statement, if `remove_all_sessions` is called synchronously while calling `session._process`.

This change fixes the issue in 2 ways (though technically 1 way would be sufficient).
1. Creates a reference to the object held by `this.local_channel_map` and uses that in both the for statement and the body of the for loop in `Connection.prototype._process`.
2. Updates `remove_all_sessions` to delete object keys instead of replacing with an object. The `for..in` loop is smart enough to skip fields that are deleted while iterating over them. I think this is slower than replacing the maps with a new object, but I don't expect this to be a hot path.