### PR TITLE
[bugfix] updates timestamp type to accept Date values

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -256,6 +256,13 @@ function write_long(buffer, value, offset) {
     }
 }
 
+function write_timestamp(buffer, value, offset) {
+    if (typeof value === 'object' && value !== null && typeof value.getTime === 'function') {
+        value = value.getTime();
+    }
+    return write_long(buffer, value, offset);
+}
+
 function read_long(buffer, offset) {
     var hi = buffer.readInt32BE(offset);
     var lo = buffer.readUInt32BE(offset + 4);
@@ -295,7 +302,7 @@ define_type('Decimal32', 0x74);
 define_type('Decimal64', 0x84);
 define_type('Decimal128', 0x94);
 define_type('CharUTF32', 0x73, buffer_uint32be_ops());
-define_type('Timestamp', 0x83, {'write':write_long, 'read':read_timestamp});
+define_type('Timestamp', 0x83, {'write':write_timestamp, 'read':read_timestamp});
 define_type('Uuid', 0x98);//TODO: convert to/from stringified form?
 define_type('Vbin8', 0xa0);
 define_type('Vbin32', 0xb0);

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -34,13 +34,13 @@ describe('message content', function() {
 
     });
 
-    function transfer_test(message: any, verification: Function) {
+    function transfer_test(message: Partial<rhea.Message>, verification: Function) {
         return function(done: Function) {
             container.on('message', function(context) {
                 verification(context.message);
                 done();
             });
-            sender.send(message);
+            sender.send(message as any);
         };
     }
 
@@ -224,8 +224,8 @@ describe('message content', function() {
         correlation_id:'correlate-me',
         content_type:'text',
         content_encoding:'ascii',
-        absolute_expiry_time:123456789,
-        creation_time:987654321,
+        absolute_expiry_time: new Date(123456789),
+        creation_time: new Date(987654321),
         group_id:'my-group',
         group_sequence:77,
         reply_to_group_id:'still-my-group',
@@ -275,8 +275,8 @@ describe('message content', function() {
         correlation_id:'correlate-me',
         content_type:'text',
         content_encoding:'ascii',
-        absolute_expiry_time:123456789,
-        creation_time:987654321,
+        absolute_expiry_time: new Date(123456789),
+        creation_time: new Date(987654321),
         group_id:'my-group',
         group_sequence:77,
         reply_to_group_id:'still-my-group',


### PR DESCRIPTION
PR #343 updated the `absolute_expiry_time` and `creation_time` MessageProperties to be the `Date` type instead of the `number` type.

For TypeScript users, this means that these fields have to be read and written as a Date. While, the `Timestamp` type was updated so that when reading the AMQP property a `Date` would be returned, the `write` operation still expected a number. This leads to `TypeError: value.copy is not a function` being thrown when a JS Date object is set for these properties.

This PR adds the `write_timestamp` function that is essentially a wrapper around `write_long`, but will 1st attempt to convert a JS Date to a number before passing it along.
