### PR TITLE
Adding in a new drain_credit() method that lets you drain without adding credits

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -367,6 +367,13 @@ Receiver.prototype.flow = function(credit) {
         this.connection._register();
     }
 };
+
+Receiver.prototype.drain_credit = function() {
+    this.drain = true;
+    this.issue_flow = true;
+    this.connection._register();
+};
+
 Receiver.prototype.add_credit = Receiver.prototype.flow;//alias
 Receiver.prototype._get_drain = function () {
     return this.drain;

--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -82,6 +82,7 @@ export declare interface Sender extends link {
 export declare interface Receiver extends link {
   drain: boolean;
   add_credit(credit: number): void;
+  drain_credit(): void;
   set_credit_window(credit_window: number): void;
 }
 


### PR DESCRIPTION
 Adding in a new drain_credit() method that lets you drain without adding in additional credits.

Fixes #357