### PR TITLE
typings: Add node 10+ Container.connect and .listen options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-coverage
+coverage*
 node_modules
 *~
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -171,28 +171,19 @@ accepting any connections.
 Connects to the server specified by the host and port supplied in the
 options and returns a <a href="#connection">Connection</a>.
 
-The options argument is an object that may contain any of the
-following fields:
+The options argument is an object that may contain node library
+[socket.connect](https://nodejs.org/api/net.html#socketconnectoptions-connectlistener)
+and
+[tls.connect](https://nodejs.org/api/tls.html#tlsconnectoptions-callback)
+options and any of the following fields:
 
-  * host
-  * port
+  * host - `socket.connect` option, defaults to localhost
+  * port - `socket.connect` option, defaults to 5672
+  * transport - undefined, 'tcp' or 'tls', determines if
+    `socket.connect` or `tls.connect` options are accepted
   * username
   * password
-  * container_id (overrides the container identifier)
-  * hostname
-  * ca (if using tls)
-  * servername (if using tls)
-  * key (if using tls with client auth)
-  * cert (if using tls with client auth)
-  * transport
   * sasl_init_hostname
-  * idle_time_out
-  * channel_max
-  * max_frame_size
-  * outgoing_locales
-  * incoming_locales
-  * sender_options
-  * receiver_options
   * reconnect
     * if true (the default), the library will automatically attempt to
       reconnect if disconnected
@@ -207,17 +198,26 @@ following fields:
   * connection_details - a function which if specified will be invoked
     to get the options to use (e.g. this can be used to alternate
     between a set of different host/port combinations)
+
+As well as Container options common for both client and server:
+
+  * id - connection name
+  * container_id - (overrides the container identifier)
+  * hostname - to present to remote in the open frame (defaults to host)
+  * max_frame_size
+  * channel_max
+  * idle_time_out
+  * outgoing_locales - in open frame
+  * incoming_locales - in open frame
+  * offered_capabilities - in open frame
+  * desired_capabilities - in open frame
+  * properties - in open frame
+  * sender_options - defaults for open_sender
+  * receiver_options - defaults for open_receiver
   * non_fatal_errors - an array of error conditions which if received
     on connection close from peer should not prevent reconnect (by
     default this only includes amqp:connection:forced)
   * all_errors_non_fatal - a boolean which determines if rhea's auto-reconnect should attempt reconnection on all fatal errors
-
-If the transport is TLS, the options may additionally specify a
-'servername' property. This allows the SNI to be controlled separately
-from the host option. If servername is not specified, the SNI will
-default to the host. If using TLS options for 'ca', 'cert' and 'key'
-may also be specified (see
-https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options)
 
 If options is undefined, the client will attempt to obtain default
 options from a JSON config file. This file is of similar structure to
@@ -232,11 +232,11 @@ The config file offers only limited configurability, specifically:
   * scheme
   * host
   * port
-  * user (note not username)
+  * user - (note not username)
   * password
-  * sasl (a nested object with field enabled)
+  * sasl - (a nested object with field enabled)
   * sasl_mechanisms
-  * tls (a nested object with fields key, cert, ca for paths to
+  * tls - (a nested object with fields key, cert, ca for paths to
     correspoding files)
   * verify
 
@@ -245,9 +245,21 @@ The config file offers only limited configurability, specifically:
 Starts a server socket listening for incoming connections on the port
 (and optionally interface) specified in the options.
 
+The options argument is an object that may contain node library
+[net.createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)
+and its
+[server.listen](https://nodejs.org/api/net.html#serverlistenoptions-callback)
+or
+[tls.createServer](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener)
+and its [server.listen](https://nodejs.org/api/tls.html#serverlisten)
+options, most AMQP Container fields listed for `connect` and any of the
+following fields:
+
 The options argument is an object that may contain any of the
 following fields:
 
+  * transport - undefined, 'tcp' or 'tls', determines if
+    `net.createServer` or `tls.createServer` options are accepted
   * host
   * port
 
@@ -320,6 +332,16 @@ object that may contain any of the following fields:
   * autosettle - Whether received messages should be automatically
     settled once the remote settles them. Defaults to true.
 
+And attach frame fields:
+
+  * snd_settle_mode
+  * rcv_settle_mode
+  * unsettled
+  * max_message_size
+  * offered_capabilities
+  * desired_capabilities
+  * properties
+
 Note: If the link doesn't specify a value for the credit_window and
 autoaccept options, the connection options are consulted followed by
 the container options. The default is used only if an option is not
@@ -349,6 +371,8 @@ object that may contain any of the following fields:
     container. If not specified a unqiue name is generated.
   * autosettle - Whether sent messages should be automatically
     settled once the peer settles them. Defaults to true.
+
+And attach frame fields as for `open_receiver`.
 
 Note: If the link doesn't specify a value for the autosettle option,
 the connection options are consulted followed by the container

--- a/lib/container.js
+++ b/lib/container.js
@@ -58,7 +58,7 @@ Container.prototype.listen = function (options) {
     var container = this;
     var server;
     if (options.transport === undefined || options.transport === 'tcp') {
-        server = net.createServer();
+        server = net.createServer(options);
         server.on('connection', function (socket) {
             new Connection(options, container).accept(socket);
         });

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -18,29 +18,27 @@
 var util = require('util');
 
 function ProtocolError(message) {
-    Error.call(this);
+    Error.captureStackTrace(this, ProtocolError);
     this.message = message;
     this.name = 'ProtocolError';
 }
 util.inherits(ProtocolError, Error);
 
 function TypeError(message) {
-    ProtocolError.call(this, message);
+    Error.captureStackTrace(this, TypeError);
     this.message = message;
     this.name = 'TypeError';
 }
-
 util.inherits(TypeError, ProtocolError);
 
 function ConnectionError(message, condition, connection) {
-    Error.call(this, message);
+    Error.captureStackTrace(this, ConnectionError);
     this.message = message;
     this.name = 'ConnectionError';
     this.condition = condition;
     this.description = message;
     Object.defineProperty(this, 'connection', { value: connection });
 }
-
 util.inherits(ConnectionError, Error);
 
 ConnectionError.prototype.toJSON = function () {

--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
         "tls": false
     },
     "dependencies": {
-        "debug": "0.8.0 - 3.5.0"
+        "debug": "^4.3.3"
     },
     "devDependencies": {
-        "@types/debug": "^0.0.30",
-        "@types/mocha": "^5.2.0",
-        "@types/node": "^8.0.37",
+        "@types/debug": "^4.1.7",
+        "@types/mocha": "^9.0.0",
+        "@types/node": "10 -",
         "browserify": "",
-        "eslint": "^4.19.1",
+        "eslint": "^7.32.0",
         "minimist": "",
-        "mocha": "^8.2.1",
+        "mocha": "^9.1.4",
         "nyc": "^15.1.0",
         "require-self": "^0.2.1",
-        "ts-node": "^7.0.0",
-        "typescript": "^3.0.1",
+        "ts-node": "^10.4.0",
+        "typescript": "^4.5.5",
         "uglify-js": "",
         "ws": "^6.0.0",
         "wtfnode": "^0.8.4"

--- a/test/connections.ts
+++ b/test/connections.ts
@@ -486,7 +486,7 @@ describe('connect string port (\'amqps\')', function () {
         listener.on('listening', function () {
             filename = 'test-connect.json';
             process.env.MESSAGING_CONNECT_FILE = filename;
-            
+
             fs.writeFile(filename, JSON.stringify({port:'amqps'}), 'utf8', function () {
                 done();
             });
@@ -524,7 +524,7 @@ describe('connect string port (\'amqp\')', function () {
         listener.on('listening', function () {
             filename = 'test-connect.json';
             process.env.MESSAGING_CONNECT_FILE = filename;
-            
+
             fs.writeFile(filename, JSON.stringify({port:'amqp'}), 'utf8', function () {
                 done();
             });

--- a/test/links.ts
+++ b/test/links.ts
@@ -916,7 +916,7 @@ describe('miscellaneous', function() {
             }
         });
         server.on('sendable', function (context: rhea.EventContext) {
-            while (context.sender!.sendable && queue.length) {
+            while (context.sender!.sendable() && queue.length) {
                 context.sender!.send({body:queue.shift()});
             }
         });
@@ -965,7 +965,7 @@ describe('miscellaneous', function() {
             }
         });
         server.on('sendable', function (context: rhea.EventContext) {
-            while (context.sender!.sendable && queue.length) {
+            while (context.sender!.sendable() && queue.length) {
                 context.sender!.send({body:queue.shift()});
             }
         });

--- a/test/reconnect.ts
+++ b/test/reconnect.ts
@@ -87,7 +87,7 @@ describe('reconnect', function() {
         var container: rhea.Container = rhea.create_container();
         var count: number = 0;
         var disconnects: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         c.open_sender('my-sender');
         c.on('disconnected', function (context) {
             disconnects++;
@@ -109,7 +109,7 @@ describe('reconnect', function() {
         var receiver_opens: number = 0;
         var sender_opens: number= 0;
         var disconnects: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         var r: rhea.Receiver = c.open_receiver('my-receiver');
         var s: rhea.Sender = c.open_sender('my-sender');
         c.on('disconnected', function (context) {
@@ -138,7 +138,7 @@ describe('reconnect', function() {
         var count: number = 0;
         var disconnects: number = 0;
         var protocol_errors: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         c.on('protocol_error', function (context) {
             protocol_errors++;
             assert.equal(protocol_errors, 1);
@@ -166,7 +166,7 @@ describe('reconnect', function() {
         var sender_opens: number = 0;
         var extra_session_opens: number = 0;
         var disconnects: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         var extra_session: rhea.Session = c.create_session();
         var s: rhea.Sender = c.open_sender('my-sender');
         extra_session.begin();
@@ -196,7 +196,7 @@ describe('reconnect', function() {
         var container: rhea.Container = rhea.create_container();
         var sender_opens: number = 0;
         var disconnects: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         var s: rhea.Sender = c.open_sender('my-sender');
         c.on('disconnected', function (context) {
             disconnects++;
@@ -308,7 +308,7 @@ describe('non-fatal error', function() {
         var container: rhea.Container = rhea.create_container();
         var count: number = 0;
         var disconnects: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         c.on('disconnected', function (context) {
             disconnects++;
         });
@@ -356,11 +356,11 @@ describe('remote close with fatal error', function() {
         var sender_opens: number = 0;
         var connection_closes: number = 0;
         var connection_errors: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         var receiver: rhea.Receiver = c.open_receiver('foo');
         var sender: rhea.Sender = c.open_sender('foo');
         c.on('disconnected', function (context) {
-            assert.fail('disconnected shouldnt have been called')
+            assert.fail('disconnected shouldnt have been called');
         });
         c.on('connection_error', function (context) {
             connection_errors++;
@@ -411,7 +411,7 @@ describe('remote close without error', function() {
         var container: rhea.Container = rhea.create_container();
         var sender_opens: number = 0;
         var connection_closes: number = 0;
-        var c: rhea.Connection = container.connect(listener.address());
+        var c: rhea.Connection = container.connect(listener.address() as any);
         var receiver: rhea.Receiver = c.open_receiver('foo');
         var sender: rhea.Sender = c.open_sender('foo');
         c.on('disconnected', function (context) {

--- a/test/sasl.ts
+++ b/test/sasl.ts
@@ -297,7 +297,7 @@ describe('user-provided sasl mechanism', function () {
                     });
                 },
                 step: function () {
-                    return new Promise(resolve => {
+                    return new Promise<void>(resolve => {
                         process.nextTick(() => {
                             stepCalled = true;
                             this.outcome = <any>true;

--- a/test/util.ts
+++ b/test/util.ts
@@ -16,7 +16,7 @@
 
 import * as assert from "assert";
 const util = require("../lib/util");
-import * as rhea from "../"
+import * as rhea from "../";
 
 describe('uuid', function() {
     it('converts uuid string to buffer', function(done) {
@@ -50,7 +50,7 @@ describe('uuid', function() {
                 failed = false;
             } catch(e) {
                 failed = true;
-                assert.equal(e.name, 'TypeError');
+                assert.equal((e as TypeError).name, 'TypeError');
             }
             if (!failed) assert.fail('did not reject invalid uuid: ' + s);
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,14 @@
     "module": "commonjs",
     "preserveConstEnums": true,
     "newLine": "LF",
-    "target": "es5",
+    "target": "es2018",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "strict": true,
     "declaration": true,
     "declarationDir": "./typings",
     "lib": [
-      "es2015"
+      "es2018"
     ]
   },
   "compileOnSave": true,

--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -1,14 +1,12 @@
 /// <reference types="node" />
 
-import { EndpointState } from "./endpoint";
 import { Session, Delivery } from "./session";
-import { Transport } from "./transport";
 import { Sender, Receiver, link } from "./link";
-import { Socket } from "net";
+import { NetConnectOpts, ListenOptions, Socket } from "net";
 import { frames } from "./frames";
 import { EventEmitter } from "events";
 import { Container } from "./container";
-import { PeerCertificate } from "tls";
+import { ConnectionOptions as TlsConnectionOptions, PeerCertificate, TlsOptions } from "tls";
 import { ConnectionError } from "./errors";
 
 /**
@@ -62,39 +60,15 @@ export interface ConnectionDetails {
 }
 
 /**
- * Defines the options that can be provided while creating a connection.
- * @interface ConnectionOptions
+ * Defines the common options that can be provided for client and server connections.
+ * @interface CommonConnectionOptions
  * @extends EndpointOptions
  */
-export interface ConnectionOptions extends EndpointOptions {
+interface CommonConnectionOptions extends EndpointOptions {
   /**
-   * @property {string} [username] - The username.
-   */
-  username?: string;
-  /**
-   * @property {string} [host] - The host to connect to.
-   */
-  host?: string;
-  /**
-   * @property {string} [hostname] - The hostname to connect to.
+   * @property {string} [hostname] - The hostname presented in `open` frame, defaults to host.
    */
   hostname?: string;
-  /**
-   * @property {string} [servername] - The name of the server.
-   */
-  servername?: string;
-  /**
-   * @property {string} [sasl_init_hostname] - The hostname for initialising sasl.
-   */
-  sasl_init_hostname?: string;
-  /**
-   * @property {number} [port] - The port number (5671 or 5672) at which to connect to.
-   */
-  port?: number;
-  /**
-   * @property {string} [transport] - The transport option. This is ignored if connection_details is set.
-   */
-  transport?: "tls" | "ssl" | "tcp";
   /**
    * @property {string} [container_id] The id of the source container. If not provided then
    * this will be the id (a guid string) of the assocaited container object. When this property is
@@ -109,38 +83,10 @@ export interface ConnectionOptions extends EndpointOptions {
    */
   container_id?: string;
   /**
-   * @property {string} [id] A unqiue name for the connection. If not provided then this will be
+   * @property {string} [id] A unique name for the connection. If not provided then this will be
    * a string in the following format: "connection-<counter>".
    */
   id?: string;
-  /**
-   * @property {boolean} [reconnect] if true (default), the library will automatically attempt to
-   * reconnect if disconnected.
-   * - if false, automatic reconnect will be disabled
-   * - if it is a numeric value, it is interpreted as the delay between
-   * reconnect attempts (in milliseconds)
-   */
-  reconnect?: boolean | number;
-  /**
-   * @property {number} [reconnect_limit] maximum number of reconnect attempts.
-   * Applicable only when reconnect is true.
-   */
-  reconnect_limit?: number;
-  /**
-   * @property {number} [initial_reconnect_delay] - Time to wait in milliseconds before
-   * attempting to reconnect. Applicable only when reconnect is true or a number is
-   * provided for reconnect.
-   */
-  initial_reconnect_delay?: number;
-  /**
-   * @property {number} [max_reconnect_delay] - Maximum reconnect delay in milliseconds
-   * before attempting to reconnect. Applicable only when reconnect is true.
-   */
-  max_reconnect_delay?: number;
-  /**
-   * @property {string} [password] - The secret key to be used while establishing the connection.
-   */
-  password?: string;
   /**
    * @property {number} [max_frame_size] The largest frame size that the sending peer
    * is able to accept on this connection. Default: 4294967295
@@ -179,11 +125,77 @@ export interface ConnectionOptions extends EndpointOptions {
    * that will be provided while creating a sender.
    */
   receiver_options?: ReceiverOptions;
+}
+
+/**
+ * Defines the common options that can be provided for client connections.
+ * @interface TcpTransportOptions
+ */
+interface NetTransportOptions {
+  /**
+   * @property {string} [transport] - The transport option. This is ignored if connection_details is set.
+   */
+   transport?: "tcp";
+ }
+
+/**
+ * Defines the common options that can be provided for TLS client connections.
+ * @interface TlsTransportOptions
+ */
+interface TlsTransportOptions {
+  /**
+   * @property {string} transport - The transport option to request TLS connection. This is ignored if connection_details is set.
+   */
+   transport: "tls" | "ssl";
+}
+
+/**
+ * Defines the common options that can be provided for client connections.
+ * @interface ClientConnectionOptions
+ * @extends CommonConnectionOptions
+ */
+interface ClientConnectionOptions extends CommonConnectionOptions {
+  /**
+   * @property {string} [username] - The username.
+   */
+  username?: string;
+  /**
+   * @property {string} [sasl_init_hostname] - The hostname for initialising sasl.
+   */
+  sasl_init_hostname?: string;
+  /**
+   * @property {boolean} [reconnect] if true (default), the library will automatically attempt to
+   * reconnect if disconnected.
+   * - if false, automatic reconnect will be disabled
+   * - if it is a numeric value, it is interpreted as the delay between
+   * reconnect attempts (in milliseconds)
+   */
+  reconnect?: boolean | number;
+  /**
+   * @property {number} [reconnect_limit] maximum number of reconnect attempts.
+   * Applicable only when reconnect is true.
+   */
+  reconnect_limit?: number;
+  /**
+   * @property {number} [initial_reconnect_delay] - Time to wait in milliseconds before
+   * attempting to reconnect. Applicable only when reconnect is true or a number is
+   * provided for reconnect.
+   */
+  initial_reconnect_delay?: number;
+  /**
+   * @property {number} [max_reconnect_delay] - Maximum reconnect delay in milliseconds
+   * before attempting to reconnect. Applicable only when reconnect is true.
+   */
+  max_reconnect_delay?: number;
+  /**
+   * @property {string} [password] - The secret key to be used while establishing the connection.
+   */
+  password?: string;
   /**
    * @property {Function} [connection_details] A function which if specified will be invoked to get the options
    * to use (e.g. this can be used to alternate between a set of different host/port combinations)
    */
-  connection_details?: (options: ConnectionOptions | number) => ConnectionDetails;
+  connection_details?: (conn_established_counter: number) => ConnectionDetails;
   /**
    * @property {string[]} [non_fatal_errors] An array of error conditions which if received on connection close
    * from peer should not prevent reconnect (by default this only includes `"amqp:connection:forced"`).
@@ -192,30 +204,29 @@ export interface ConnectionOptions extends EndpointOptions {
   /**
    * @property {boolean} [all_errors_non_fatal] Determines if rhea's auto-reconnect should attempt reconnection on all fatal errors
    */
-   all_errors_non_fatal?: boolean,
-  /**
-   * @property {string} [key] The private key of the certificate to be used with tls connection option
-   */
-  key?: string,
-  /**
-   * @property {string} [cert] The certificate to be used with tls connection option
-   */
-  cert?: string,
-  /**
-   * @property {string} [ca] The CA certificate used for signing certificate to be used with tls connection option
-   */
-  ca?: string,
-  /**
-   * @property {boolean} [requestCert] Flag to indicate client authentication to be used with tls connection option
-   * This is used in opening socket by nodejs
-   */
-  requestCert?: boolean,
-  /**
-   * @property {boolean} [rejectUnauthorized] Flag to indicate if certificate is self signed to be used with tls connection option
-   * This is used in opening socket by nodejs
-   */
-  rejectUnauthorized?: boolean
+  all_errors_non_fatal?: boolean;
 }
+
+type NetClientConnectionOptions = NetTransportOptions & ClientConnectionOptions & NetConnectOpts
+type TlsClientConnectionOptions = TlsTransportOptions & ClientConnectionOptions & TlsConnectionOptions
+
+export type ConnectionOptions = NetClientConnectionOptions | TlsClientConnectionOptions;
+
+/** `net.createServer` options that have no own type in @types/node@10.17.60 */
+type NetOptions = { allowHalfOpen?: boolean, pauseOnConnect?: boolean }
+/**
+ * Defines the options that can be provided while creating a server connection.
+ */
+type NetServerConnectionOptions = NetTransportOptions & CommonConnectionOptions & ListenOptions & NetOptions
+/**
+ * Defines the options that can be provided while creating a TLS server connection.
+ */
+type TlsServerConnectionOptions = TlsTransportOptions & CommonConnectionOptions & ListenOptions & TlsOptions
+
+/**
+ * Defines the options that can be provided while creating a server connection.
+ */
+export type ServerConnectionOptions = NetServerConnectionOptions | TlsServerConnectionOptions
 
 /**
  * Defines the common set of options that can be provided while creating a link (sender, receiver).
@@ -287,6 +298,7 @@ export interface BaseTerminusOptions {
 /**
  * Defines the options that can be provided while creating the source for a Sender or Receiver (link).
  * @interface TerminusOptions
+ * @extends BaseTerminusOptions
  */
 export interface TerminusOptions extends BaseTerminusOptions {
   /**
@@ -298,6 +310,7 @@ export interface TerminusOptions extends BaseTerminusOptions {
 /**
  * Defines the options that can be provided while creating the target for a Sender or Receiver (link).
  * @interface TargetTerminusOptions
+ * @extends BaseTerminusOptions
  */
 export interface TargetTerminusOptions extends BaseTerminusOptions {
   /**
@@ -309,6 +322,7 @@ export interface TargetTerminusOptions extends BaseTerminusOptions {
 /**
  * Describes the source.
  * @interface Source
+ * @extends TerminusOptions
  */
 export interface Source extends TerminusOptions {
   /**
@@ -538,7 +552,8 @@ export interface MessageFooter {
 /**
  * Describes the AMQP message that is sent or received on the wire.
  * @interface Message
- * @extends MessageProperties, MessageHeader
+ * @extends MessageProperties
+ * @extends MessageHeader
  */
 export interface Message extends MessageProperties, MessageHeader {
   /**

--- a/typings/container.d.ts
+++ b/typings/container.d.ts
@@ -5,9 +5,9 @@ import { generate_uuid, string_to_uuid, uuid_to_string } from "./util";
 import { ws } from "./ws";
 import { filter } from "./filter";
 import { EventEmitter } from "events";
-import { Connection, ConnectionOptions } from "./connection";
-import { ListenOptions, Server, Socket } from "net";
-import { TlsOptions, Server as TlsServer, ConnectionOptions as TlsConnectionOptions } from "tls";
+import { Connection, ConnectionOptions, ServerConnectionOptions, TlsServerConnectionOptions } from "./connection";
+import { Server, Socket } from "net";
+import { Server as TlsServer, ConnectionOptions as TlsConnectionOptions } from "tls";
 import { message } from "./message";
 import { types } from "./types";
 
@@ -23,7 +23,8 @@ export declare interface Container extends EventEmitter {
   sasl_server_mechanisms: any;
   connect(options?: ConnectionOptions): Connection;
   create_connection(options?: ConnectionOptions): Connection;
-  listen(options: ListenOptions | TlsOptions): Server | TlsServer;
+  listen(options: TlsServerConnectionOptions): TlsServer;
+  listen(options: ServerConnectionOptions): Server;
   create_container(options?: ContainerOptions): Container;
   get_option(name: string, default_value: any): any;
   generate_uuid: generate_uuid;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,8 +4,8 @@ export {
   AmqpError, Message, MessageAnnotations, MessageProperties,
   Connection, ConnectionOptions, EventContext, DeliveryAnnotations, Dictionary,
   EndpointOptions, LinkOptions, ReceiverOptions, SenderOptions, TerminusOptions,
-  ConnectionEvents, MessageHeader, OnAmqpEvent, Source, TargetTerminusOptions,
-  ConnectionDetails
+  ConnectionEvents, MessageHeader, OnAmqpEvent, ServerConnectionOptions, Source,
+  TargetTerminusOptions, ConnectionDetails
 } from "./connection";
 export { ConnectionError, ProtocolError, TypeError, SimpleError } from "./errors";
 export { Delivery, Session, SessionEvents } from "./session";


### PR DESCRIPTION
Some node library server and client options were missing in typings.
Use the definitions from @types/node to make them complete.
Typings did not validate for consistent TLS vs TCP vs IPC options.

The [tls.Server](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener) can take options, but they were not passed to it.

Had old @types for node and mocha and old typescript, as tests now run from
node 10 up. Some tests did not parse with new typescript and had errors.

Protocol and connection errors did not capture stack traces.
