### PR TITLE
Add Map and Set wrapping

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -417,11 +417,24 @@ types.wrap_list = function(l) {
     var items = l.map(types.wrap);
     return types.List32(items);
 };
+types.wrap_set_as_list = function(l) {
+    if (l.size === 0) return types.List0();
+    var items = Array.from(l, types.wrap);
+    return types.List32(items);
+};
 types.wrap_map = function(m, key_wrapper) {
     var items = [];
     for (var k in m) {
         items.push(key_wrapper ? key_wrapper(k) : types.wrap(k));
         items.push(types.wrap(m[k]));
+    }
+    return types.Map32(items);
+};
+types.wrap_map_as_map = function(m) {
+    var items = [];
+    for (var [k, v] of m) {
+        items.push(types.wrap(k));
+        items.push(types.wrap(v));
     }
     return types.Map32(items);
 };
@@ -470,6 +483,10 @@ types.wrap = function(o) {
         return types.Null();
     } else if (Array.isArray(o)) {
         return types.wrap_list(o);
+    } else if (o instanceof Map) {
+        return types.wrap_map_as_map(o);
+    } else if (o instanceof Set) {
+        return types.wrap_set_as_list(o);
     } else {
         return types.wrap_map(o);
     }

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -215,6 +215,23 @@ describe('message content', function() {
         }
 
     }));
+    it('sends Map and receives object with string keys', transfer_test({body: new Map(Object.entries({ a: 1, b: "c" }))}, function(message: rhea.Message) {
+        assert.equal(message.body.a, 1);
+        assert.equal(message.body.b, "c");
+    }));
+    it('sends Map and receives object with string and number keys', transfer_test({body: new Map<any, any>([["a", 1], [2, "c"]])}, function(message: rhea.Message) {
+        assert.equal(message.body.a, 1);
+        assert.equal(message.body[2], "c");
+    }));
+    it('sends Map and receives object with uuid keys', transfer_test({body: new Map<any, any>([[amqp_types.wrap_uuid(Buffer.alloc(16)), 1]])}, function(message: rhea.Message) {
+
+        assert.equal(message.body[Buffer.alloc(16).toString()], 1);
+    }));
+    it('sends Set and receives Array', transfer_test({body: new Set([1, "a", Buffer.alloc(16)])}, function(message: rhea.Message) {
+        assert.equal(message.body[0], 1);
+        assert.equal(message.body[1], "a");
+        assert(Buffer.alloc(16).equals(message.body[2]), `Buffer ${message.body[2]} == Buffer.alloc(16)`);
+    }));
     it('get header and properties directly', transfer_test({
         message_id:'my-id',
         user_id:'my-user',


### PR DESCRIPTION
Was unable to create AMQP maps with something else but strings and symbols as keys. Set can also be wrapped as a list.

This also decodes by Javascript calling toString implicitly on the key value.
