### PR TITLE
Use toRheaTyped to wrap custom types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -50,6 +50,10 @@ Typed.prototype.toJSON = function() {
     return this.value && this.value.toJSON ? this.value.toJSON() : this.value;
 };
 
+Typed.prototype.toRheaTyped = function() {
+    return this;
+};
+
 function TypeDesc(name, typecode, props, empty_value) {
     this.name = name;
     this.typecode = typecode;
@@ -438,7 +442,9 @@ types.wrap_array = function(l, code, descriptors) {
 };
 types.wrap = function(o) {
     var t = typeof o;
-    if (t === 'string') {
+    if (t === 'object' && o !== null && typeof o.toRheaTyped === 'function') {
+        return o.toRheaTyped();
+    } else if (t === 'string') {
         return types.wrap_string(o);
     } else if (t === 'boolean') {
         return o ? types.True() : types.False();
@@ -462,8 +468,6 @@ types.wrap = function(o) {
         }
     } else if (o instanceof Date) {
         return types.wrap_timestamp(o.getTime());
-    } else if (o instanceof Typed) {
-        return o;
     } else if (o instanceof Buffer || o instanceof Uint8Array) {
         return types.wrap_binary(o);
     } else if (t === 'undefined' || o === null) {

--- a/test/messages.ts
+++ b/test/messages.ts
@@ -338,6 +338,17 @@ describe('message content', function() {
         });
         sender.send(message, undefined, 1111);
     });
+
+    var customMessage = {
+        a: 1,
+        toRheaTyped() {
+            return amqp_types.wrap_map({b: 2})
+        }
+    }
+    it('message has a custom type', transfer_test({body:customMessage}, function(message: rhea.Message) {
+        assert.equal(message.body.b, 2)
+        assert.equal(Object.keys(message.body).length, 1)
+    }));
 });
 
 describe('acknowledgement', function() {


### PR DESCRIPTION
Having to convert your data for sending as a message makes use more
complicated.

This allows defining toRheaTyped to your types so you can send them without wrapping them beforehand. The Typed object is turned into a custom type of itself.

There would be use for a function like the replacer function in [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) to handle types received from other libraries. But I did not see any immediate easy and efficient solution to having it defined. Maybe some kind of option you could pass on send or add on message, link, session or container.