### PR TITLE
remove [stale] branch restriction from CI job push trigger

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,6 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     types: [ opened, reopened, synchronize ]
 


### PR DESCRIPTION
The CI workflow has a restriction on the push trigger so that it only builds for the 'master' branch. The default branch was renamed to 'main' some time ago so CI stopped working for such pushes entirely, the restriction should be updated.

Also, for people working on forks, where the default branch often isnt used for development, it means the worklow wont run (if actions was manually enabled on the fork). Its useful to run the CI on forks when e.g preparing changes before raising a PR.

Given both of those the best update seemed to be removing the branch restriction.