### PR TITLE
docs: update the "websocket echo server example" url

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ that in the node module 'ws'.
 
 Used to start handling an incoming websocket connection as an AMQP
 connection. See the [websocket echo server
-example](example/websocket/echo.js) for how to use it.
+example](examples/websockets/echo.js) for how to use it.
 
 ---------------------------------------------------------------------
 ### Connection


### PR DESCRIPTION
The url of "websocket echo server example" in README was not accessible correctly, I fixed it