### PR TITLE
Raise max listener limit for connections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,6 +32,7 @@ var tls = require('tls');
 var EventEmitter = require('events').EventEmitter;
 
 var AMQP_PROTOCOL_ID = 0x00;
+const MAX_LISTENER_LIMIT = 1000;
 
 function find_connect_config() {
     var paths;
@@ -245,6 +246,7 @@ var Connection = function (options, container) {
     this.scheduled_reconnect = undefined;
     this.default_sender = undefined;
     this.closed_with_non_fatal_error = false;
+    this.setMaxListeners(MAX_LISTENER_LIMIT);
 
     var self = this;
     aliases.forEach(function (alias) { Object.defineProperty(self, alias, { get: remote_property_shortcut(alias) }); });


### PR DESCRIPTION
This warning from NodeJS is emitted when there are more than 10 connections in one session and they're being closed:

> (node:7050) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnected listeners added to [Connection]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)

Although this warning is generally helpful in detecting leaks, the user has already made a conscious decision to connect to that many connections and the warning is not helpful to them in this context. They're already trying to close those connections, and, in that process, we need to install listeners for disconnection events.

To disable this warning, this PR raises the limit on max listeners to 1000 for connections. 