### PR TITLE
[fix]: message annotations on modified message

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -287,7 +287,7 @@ define_outcome({
     fields:[
         {name:'delivery_failed', type:'boolean'},
         {name:'undeliverable_here', type:'boolean'},
-        {name:'message_annotations', type:'map'}
+        {name:'message_annotations', type:'symbolic_map'}
     ]});
 
 module.exports = message;


### PR DESCRIPTION
Hello, as we explained in the issue https://github.com/amqp/rhea/issues/441, it seems like `message_annotations`
are encoded as a simble map in the modified outcome of the message, we opened this pr for changing the encoding of `message_annotations` into a symbolic_map.
We made tests in our local environment with a rabbitmq-server and without the message_annotations we see no error from the server.