### PR TITLE
Replace `/// <reference types="node" />` with explicit `import type` in typings

### DIFF
--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { Session, Delivery } from "./session";
 import { Sender, Receiver, link } from "./link";
 import { NetConnectOpts, ListenOptions, Socket } from "net";

--- a/typings/container.d.ts
+++ b/typings/container.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 import { sasl } from "./sasl";
 import { generate_uuid, string_to_uuid, uuid_to_string } from "./util";

--- a/typings/endpoint.d.ts
+++ b/typings/endpoint.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 export declare interface EndpointState {
   local_open: boolean;

--- a/typings/errors.d.ts
+++ b/typings/errors.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 export declare interface ProtocolError extends Error {
     message: string;

--- a/typings/filter.d.ts
+++ b/typings/filter.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 import * as types from "./types";
 

--- a/typings/frames.d.ts
+++ b/typings/frames.d.ts
@@ -1,4 +1,5 @@
-/// <reference types="node" />
+import type { Buffer } from "buffer";
+
 
 export interface header {
   [x: string]: any;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 export { link, LinkError, Receiver, Sender, ReceiverEvents, SenderEvents } from "./link";
 export {
   AmqpError, Message, MessageAnnotations, MessageProperties,

--- a/typings/link.d.ts
+++ b/typings/link.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { EventEmitter } from "events";
 import { frames } from "./frames";
 import { EndpointState } from "./endpoint";

--- a/typings/message.d.ts
+++ b/typings/message.d.ts
@@ -1,4 +1,5 @@
-/// <reference types="node" />
+import type { Buffer } from "buffer";
+
 
 export declare interface Message {
   [x: string]: any;

--- a/typings/sasl.d.ts
+++ b/typings/sasl.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { Connection } from "./connection";
 import { Transport } from "./transport";
 import { Socket } from "net";

--- a/typings/session.d.ts
+++ b/typings/session.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { Connection, EventContext } from "./connection";
 import { EndpointState } from "./endpoint";
 import { EventEmitter } from "events";

--- a/typings/terminus.d.ts
+++ b/typings/terminus.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 declare let terminus: any;
 export function unwrap(field: any): any | null;

--- a/typings/transport.d.ts
+++ b/typings/transport.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { header, frames } from "./frames";
 import { Socket } from "net";
 

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 
+import type { Buffer } from "buffer";
 import { frames } from "./frames";
 
 export interface ICompositeType {

--- a/typings/util.d.ts
+++ b/typings/util.d.ts
@@ -1,4 +1,5 @@
-/// <reference types="node" />
+import type { Buffer } from "buffer";
+
 export type generate_uuid = () => string;
 export type uuid4 = () => Buffer;
 export type uuid_to_string = (buffer: Buffer) => string;

--- a/typings/ws.d.ts
+++ b/typings/ws.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 
 /**
  * Describes the required shape of WebSocket instances.


### PR DESCRIPTION
Remove the triple-slash directive `/// <reference types="node" />` from all 16 typing files in `typings/`. This directive injects the entire `@types/node` global namespace into any TypeScript project that imports rhea, even when compiling for non-Node targets (React Native, browser, Cloudflare Workers), causing type conflicts.

## What changed

- **Removed** `/// <reference types="node" />` from all 16 `.d.ts` files
- **Added** `import type { Buffer } from "buffer"` to the 9 files that use `Buffer` without an explicit import (`connection.d.ts`, `frames.d.ts`, `link.d.ts`, `message.d.ts`, `sasl.d.ts`, `session.d.ts`, `transport.d.ts`, `types.d.ts`, `util.d.ts`)
- Files that already had explicit `import { ... } from "events"` / `import { ... } from "net"` needed no additional changes

## Why

The `/// <reference types="node" />` is a legacy pattern from before `import type` existed. It pulls in all Node.js type definitions globally, which conflicts with other platform type definitions (e.g., `react-native`, `lib.dom.d.ts`) that define the same globals (`FormData`, `AbortController`, `Blob`, etc.).

Using explicit `import type` resolves identically for Node consumers (since `@types/node` provides the `"buffer"`, `"events"`, and `"net"` modules) but avoids polluting consumers' global type namespace.

## Validation

- `tsc --noEmit` passes with zero errors
- Non-breaking change: all types resolve identically for Node consumers

Fixes #446